### PR TITLE
Fixing the dicom-server Helm chart

### DIFF
--- a/helm/dicom-server/templates/_helpers.tpl
+++ b/helm/dicom-server/templates/_helpers.tpl
@@ -61,3 +61,15 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+ Postgres Password lookup
+*/}}
+{{- define "dicom.postgres.password" -}}
+{{- $localpass := (lookup "v1" "Secret" "postgres" "postgres-postgresql" ) -}}
+{{- if $localpass }}
+{{- default (index $localpass.data "postgres-password" | b64dec) }}
+{{- else }}
+{{- default .Values.secrets.password }}
+{{- end }}
+{{- end }}

--- a/helm/dicom-server/templates/config-volume-g3auto.yaml
+++ b/helm/dicom-server/templates/config-volume-g3auto.yaml
@@ -8,7 +8,7 @@ stringData:
         {
           "db_host": {{ .Values.secrets.host | quote }},
           "db_username": {{ .Values.secrets.userName | quote }},
-          "db_password": {{ .Values.secrets.password | quote }},
+          "db_password": {{ include "dicom.postgres.password" . | quote }},
           "db_database": {{ .Values.secrets.dataBase | quote }}
         }
   orthanc_config_overwrites.json: |
@@ -21,7 +21,7 @@ stringData:
             "Host": {{ .Values.secrets.host | quote }},
             "Database": {{ .Values.secrets.dataBase | quote }},
             "Username": {{ .Values.secrets.userName | quote }},
-            "Password": {{ .Values.secrets.password | quote }},
+            "Password": {{ include "dicom.postgres.password" . | quote }},
             "IndexConnectionsCount": {{ .Values.secrets.indexConnectionsCount }},
             "Lock": {{ .Values.secrets.lock }}
           },


### PR DESCRIPTION
adding a lookup function to lookup the local postgres password for dicom-server