### PR TITLE
adding a job to create indices so guppy pod can run on startup

### DIFF
--- a/helm/gen3-test-data-job/Chart.yaml
+++ b/helm/gen3-test-data-job/Chart.yaml
@@ -10,7 +10,7 @@ description: A Helm chart for generating dummy data in gen3
 # Library charts provide useful utilities or functions for the chart developer. They're included as
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
-type: application
+type: library
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.

--- a/helm/gen3-test-data-job/templates/_jobs.tpl
+++ b/helm/gen3-test-data-job/templates/_jobs.tpl
@@ -1,0 +1,232 @@
+
+{{/* 
+Generate Test data
+*/}}
+{{- define "gen3-test-data-job.gentestdata-job" -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gentestdata-job-{{ randAlphaNum 6 | lower }}
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: gen3job
+    spec:
+      serviceAccountName: useryaml-job
+      volumes:
+        - name: yaml-merge
+          configMap:
+            name: "fence-yaml-merge"
+        - name: shared-data
+          emptyDir: {}
+# -----------------------------------------------------------------------------
+# DEPRECATED! Remove when all commons are no longer using local_settings.py
+#             for fence.
+# -----------------------------------------------------------------------------
+        - name: old-config-volume
+          secret:
+            secretName: "fence-secret"
+        - name: creds-volume
+          secret:
+            secretName: "fence-creds"
+        - name: config-helper
+          configMap:
+            name: config-helper
+        - name: json-secret-volume
+          secret:
+            secretName: "fence-json-secret"
+# -----------------------------------------------------------------------------
+        - name: config-volume
+          secret:
+            secretName: "fence-config"
+        - name: fence-jwt-keys
+          secret:
+            secretName: "fence-jwt-keys"
+      containers:
+      - name: auto-qa
+        image: quay.io/cdis/data-simulator:master
+        imagePullPolicy: Always
+        env:
+          - name: PYTHONPATH
+            value: /var/www/fence
+          - name: DICTIONARY_URL
+            valueFrom:
+              configMapKeyRef:
+                name: manifest-global
+                key: dictionary_url
+          - name: HOSTNAME
+            valueFrom:
+              configMapKeyRef:
+                name: global
+                key: hostname
+          - name: TEST_PROGRAM
+            value: "{{ .Values.gentestdata.test_program }}"
+          - name: TEST_PROJECT
+            value: "{{ .Values.gentestdata.test_project  }}"
+          - name: MAX_EXAMPLES
+            value: "{{ .Values.gentestdata.max_examples }}"
+          - name: SUBMISSION_ORDER
+            value: "{{ .Values.gentestdata.submission_order }}"
+        volumeMounts:
+          - name: shared-data
+            mountPath: /mnt/shared
+        command: ["/bin/bash" ]
+        args:
+          - "-c"
+          - |
+            let count=0
+            while [[ ! -f /mnt/shared/access_token.txt && $count -lt 50 ]]; do
+              echo "waiting for /mnt/shared/access_token.txt";
+              sleep 2
+              let count=$count+1
+            done
+
+            mkdir -p /TestData
+            data-simulator simulate --url $DICTIONARY_URL --path /TestData --program $TEST_PROGRAM --project $TEST_PROJECT --max_samples $MAX_EXAMPLES
+
+            echo "define submission order"
+            data-simulator submission_order --url $DICTIONARY_URL --path /TestData --node_name $SUBMISSION_ORDER
+
+            echo "Preparing to submit data"
+            data-simulator submitting_data --host https://$HOSTNAME --dir /TestData/ --project "$TEST_PROGRAM/$TEST_PROJECT" --access_token /mnt/shared/access_token.txt
+            echo "All Done - always succeed to avoid k8s retries"
+      - name: fence
+        image: {{ .Values.fence.image }}
+        imagePullPolicy: Always
+        env:
+          - name: PYTHONPATH
+            value: /var/www/fence
+          - name: SUBMISSION_USER
+            value: "{{ .Values.gentestdata.submission_user }}"
+          - name: TOKEN_EXPIRATION
+            value: "3600"
+          - name: FENCE_PUBLIC_CONFIG
+            valueFrom:
+              configMapKeyRef:
+                name: manifest-fence
+                key: fence-config-public.yaml
+                optional: true
+        volumeMounts:
+# -----------------------------------------------------------------------------
+# DEPRECATED! Remove when all commons are no longer using local_settings.py
+#             for fence.
+# -----------------------------------------------------------------------------
+          - name: "old-config-volume"
+            readOnly: true
+            mountPath: "/var/www/fence/local_settings.py"
+            subPath: local_settings.py
+          - name: "creds-volume"
+            readOnly: true
+            mountPath: "/var/www/fence/creds.json"
+            subPath: creds.json
+          - name: "config-helper"
+            readOnly: true
+            mountPath: "/var/www/fence/config_helper.py"
+            subPath: config_helper.py
+          - name: "json-secret-volume"
+            readOnly: true
+            mountPath: "/var/www/fence/fence_credentials.json"
+            subPath: fence_credentials.json
+# -----------------------------------------------------------------------------
+          - name: "config-volume"
+            readOnly: true
+            mountPath: "/var/www/fence/fence-config-secret.yaml"
+            subPath: fence-config.yaml
+          - name: "yaml-merge"
+            readOnly: true
+            mountPath: "/var/www/fence/yaml_merge.py"
+            subPath: yaml_merge.py
+          - name: "fence-jwt-keys"
+            readOnly: true
+            mountPath: "/fence/jwt-keys.tar"
+            subPath: "jwt-keys.tar"
+          - name: shared-data
+            mountPath: /mnt/shared
+        command: ["/bin/bash" ]
+        args:
+            - "-c"
+            - |
+              echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
+              python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+              if [ -f /fence/jwt-keys.tar ]; then
+                cd /fence
+                tar xvf jwt-keys.tar
+                if [ -d jwt-keys ]; then
+                  mkdir -p keys
+                  mv jwt-keys/* keys/
+                fi
+              fi
+              echo "generate access token"
+              echo "fence-create --path fence token-create --type access_token --username $SUBMISSION_USER  --scopes openid,user,test-client --exp $TOKEN_EXPIRATION"
+              tempFile="$(mktemp -p /tmp token.txt_XXXXXX)"
+              success=false
+              count=0
+              sleepTime=10
+              # retry loop
+              while [[ $count -lt 3 && $success == false ]]; do
+                if fence-create --path fence token-create --type access_token --username $SUBMISSION_USER  --scopes openid,user,test-client --exp $TOKEN_EXPIRATION > "$tempFile"; then
+                  echo "fence-create success!"
+                  tail -1 "$tempFile" > /mnt/shared/access_token.txt
+                  # base64 --decode complains about invalid characters - don't know why
+                  awk -F . '{ print $2 }' /mnt/shared/access_token.txt | base64 --decode 2> /dev/null
+                  success=true
+                else
+                  echo "fence-create failed!"
+                  cat "$tempFile"
+                  echo "sleep for $sleepTime, then retry"
+                  sleep "$sleepTime"
+                  let sleepTime=$sleepTime+$sleepTime
+                fi
+                let count=$count+1
+              done
+              if [[ $success != true ]]; then
+                echo "Giving up on fence-create after $count retries - failed to create valid access token"
+              fi
+              echo ""
+              echo "All Done - always succeed to avoid k8s retries"
+      restartPolicy: Never
+{{- end }}
+
+{{/* 
+A job that will create test indices with data for guppy to run upon 
+deployment since it requires indices to be present.
+*/}}
+{{- define "gen3-test-data-job.create-test-indices" -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-test-indices
+  annotations:
+    "helm.sh/hook": "pre-install"
+spec:
+  template:
+    metadata:
+      labels:
+        app: gen3job
+    spec:
+      restartPolicy: Never
+    #   serviceAccountName: gitops-sa
+    #   securityContext:
+    #     fsGroup: 1000
+      containers:
+        - name: create-indices
+          image: quay.io/cdis/awshelper:feat_GPE-572
+          imagePullPolicy: Always
+          env:
+            # - name: gen3Env
+            #   valueFrom:
+            #     configMapKeyRef:
+            #       name: global
+            #       key: environment
+            # - name: JENKINS_HOME
+            #   value: "devterm"
+            - name: GEN3_HOME
+              value: /home/ubuntu/cloud-automation
+          command: [ "/bin/bash" ]
+          args:
+            - "-c"
+            - |
+              bash ~/cloud-automation/files/scripts/test-indices/create-test-indices.sh
+{{- end }}

--- a/helm/guppy/Chart.yaml
+++ b/helm/guppy/Chart.yaml
@@ -22,3 +22,8 @@ version: 0.0.1
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "2022.10"
+
+dependencies:
+  - name: gen3-test-data-job
+    version: 0.0.1
+    repository: file://../gen3-test-data-job

--- a/helm/guppy/templates/appInit.yaml
+++ b/helm/guppy/templates/appInit.yaml
@@ -1,0 +1,1 @@
+{{- include "gen3-test-data-job.create-test-indices" . }}

--- a/helm/guppy/values.yaml
+++ b/helm/guppy/values.yaml
@@ -113,11 +113,11 @@ service:
 
 #Configmap
 indices: 
-- index: etl
-  type: subject
-- index: file
+- index: dev_case
+  type: case
+- index: dev_file
   type: file
-configIndex: array-config
+configIndex: dev_case-array-config
 authFilterField: auth_resource_path
 enableEncryptWhitelist: true
 encryptWhitelist: test1

--- a/helm/portal/defaults/gitops.json
+++ b/helm/portal/defaults/gitops.json
@@ -1,2 +1,258 @@
-{}
+{
+    "graphql": {
+      "boardCounts": [
+        {
+          "graphql": "_case_count",
+          "name": "Case",
+          "plural": "Cases"
+        },
+        {
+          "graphql": "_experiment_count",
+          "name": "Experiment",
+          "plural": "Experiments"
+        },
+        {
+          "graphql": "_aliquot_count",
+          "name": "Aliquot",
+          "plural": "Aliquots"
+        }
+      ],
+      "chartCounts": [
+        {
+          "graphql": "_case_count",
+          "name": "Case"
+        },
+        {
+          "graphql": "_experiment_count",
+          "name": "Experiment"
+        },
+        {
+          "graphql": "_aliquot_count",
+          "name": "Aliquot"
+        }
+      ],
+      "projectDetails": "boardCounts"
+    },
+    "components": {
+      "appName": "Generic Data Commons Portal",
+      "index": {
+        "introduction": {
+          "heading": "Data Commons",
+          "text": "The Generic Data Commons supports the management, analysis and sharing of data for the research community.",
+          "link": "/submission"
+        },
+        "buttons": [
+          {
+            "name": "Define Data Field",
+            "icon": "data-field-define",
+            "body": "The Generic Data Commons define the data in a general way. Please study the dictionary before you start browsing.",
+            "link": "/DD",
+            "label": "Learn more"
+          },
+          {
+            "name": "Explore Data",
+            "icon": "data-explore",
+            "body": "The Exploration Page gives you insights and a clear overview under selected factors.",
+            "link": "/explorer",
+            "label": "Explore data"
+          },
+          {
+            "name": "Access Data",
+            "icon": "data-access",
+            "body": "Use our selected tool to filter out the data you need.",
+            "link": "/query",
+            "label": "Query data"
+          },
+          {
+            "name": "Submit Data",
+            "icon": "data-submit",
+            "body": "Submit Data based on the dictionary.",
+            "link": "/submission",
+            "label": "Submit data"
+          }
+        ]
+      },
+      "navigation": {
+        "title": "Generic Data Commons",
+        "items": [
+          {
+            "icon": "dictionary",
+            "link": "/DD",
+            "color": "#a2a2a2",
+            "name": "Dictionary"
+          },
+          {
+            "icon": "exploration",
+            "link": "/explorer",
+            "color": "#a2a2a2",
+            "name": "Exploration"
+          },
+          {
+            "icon": "query",
+            "link": "/query",
+            "color": "#a2a2a2",
+            "name": "Query"
+          },
+          {
+            "icon": "workspace",
+            "link": "/workspace",
+            "color": "#a2a2a2",
+            "name": "Workspace"
+          },
+          {
+            "icon": "profile",
+            "link": "/identity",
+            "color": "#a2a2a2",
+            "name": "Profile"
+          }
+        ]
+      },
+      "topBar": {
+        "items": [
+          {
+            "icon": "upload",
+            "link": "/submission",
+            "name": "Submit Data"
+          },
+          {
+            "link": "https://gen3.org/resources/user",
+            "name": "Documentation"
+          }
+        ]
+      },
+      "login": {
+        "title": "Generic Data Commons",
+        "subTitle": "Explore, Analyze, and Share Data",
+        "text": "This website supports the management, analysis and sharing of human disease data for the research community and aims to advance basic understanding of the genetic basis of complex traits and accelerate discovery and development of therapies, diagnostic tests, and other technologies for diseases like cancer.",
+        "contact": "If you have any questions about access or the registration process, please contact ",
+        "email": "support@datacommons.io"
+      },
+      "certs": {},
+      "footerLogos": [
+        {
+          "src": "/src/img/gen3.png",
+          "href": "https://ctds.uchicago.edu/gen3",
+          "alt": "Gen3 Data Commons"
+        },
+        {
+          "src": "/src/img/createdby.png",
+          "href": "https://ctds.uchicago.edu/",
+          "alt": "Center for Translational Data Science at the University of Chicago"
+        }
+      ]
+    },
+    "requiredCerts": [],
+    "featureFlags": {
+      "explorer": true,
+      "noIndex": true,
+      "analysis": false,
+      "discovery": false,
+      "discoveryUseAggMDS": false,
+      "studyRegistration": false
+    },
+    "dataExplorerConfig": {
+      "charts": {
+        "project_id": {
+          "chartType": "count",
+          "title": "Projects"
+        },
+        "case_id": {
+          "chartType": "count",
+          "title": "Cases"
+        },
+        "gender": {
+          "chartType": "pie",
+          "title": "Gender"
+        },
+        "race": {
+          "chartType": "bar",
+          "title": "Race"
+        }
+      },
+      "filters": {
+        "tabs": [
+          {
+            "title": "Case",
+            "fields":[
+              "project_id",
+              "gender",
+              "race",
+              "ethnicity"
+            ]
+          }
+        ]
+      },
+      "table": {
+        "enabled": false
+      },
+      "dropdowns": {},
+      "buttons": [],
+      "guppyConfig": {
+        "dataType": "case",
+        "nodeCountTitle": "Cases",
+        "fieldMapping": [
+          { "field": "disease_type", "name": "Disease type" },
+          { "field": "primary_site", "name": "Site where samples were collected"}
+        ],
+        "manifestMapping": {
+          "resourceIndexType": "file",
+          "resourceIdField": "object_id",
+          "referenceIdFieldInResourceIndex": "case_id",
+          "referenceIdFieldInDataIndex": "node_id"
+        },
+        "accessibleFieldCheckList": ["case_id"],
+        "accessibleValidationField": "case_id"
+      }
+    },
+    "fileExplorerConfig": {
+      "charts": {
+        "data_type": {
+          "chartType": "stackedBar",
+          "title": "File Type"
+        },
+        "data_format": {
+          "chartType": "stackedBar",
+          "title": "File Format"
+        }
+      },
+      "filters": {
+        "tabs": [
+          {
+            "title": "File",
+            "fields": [
+              "project_id",
+              "data_type",
+              "data_format"
+            ]
+          }
+        ]
+      },
+      "table": {
+        "enabled": true,
+        "fields": [
+          "project_id",
+          "file_name",
+          "file_size",
+          "object_id"
+        ]
+      },
+      "dropdowns": {},
+      "guppyConfig": {
+        "dataType": "file",
+        "fieldMapping": [
+          { "field": "object_id", "name": "GUID" }
+        ],
+        "nodeCountTitle": "Files",
+        "manifestMapping": {
+          "resourceIndexType": "case",
+          "resourceIdField": "case_id",
+          "referenceIdFieldInResourceIndex": "object_id",
+          "referenceIdFieldInDataIndex": "object_id"
+        },
+        "accessibleFieldCheckList": ["case_id"],
+        "accessibleValidationField": "case_id",
+        "downloadAccessor": "object_id"
+      }
+    }
+  }
 

--- a/helm/ssjdispatcher/templates/service.yaml
+++ b/helm/ssjdispatcher/templates/service.yaml
@@ -11,5 +11,5 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-  selector:k get 
+  selector:
     {{- include "ssjdispatcher.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
- The Guppy services requires there to be indices in elasticsearch in order for to run properly. I created a job that will run by adding indices to elasticsearch and uploading bogus data into them. 
- I converted Ed's "gen-3-test-data-job" chart into a library chart to allow it to be used in other charts. 
- I made guppy dependent on the "create-test-indices" job
