### PR TITLE
Add small fixes, pin peregrine to 2023.01, portal to master

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-03-03T20:55:43Z",
+  "generated_at": "2023-03-13T17:32:44Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -88,21 +88,20 @@
         "hashed_secret": "2546383b95bb44732e9be6a877fd476c0442fdab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 37,
+        "line_number": 38,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "d84ce25b0f9bc2cc263006ae39453efb22cc2900",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 39,
+        "line_number": 40,
         "type": "Secret Keyword"
       },
       {
-        "hashed_secret": "abb751db44bcfd1bb9d4ad53e40138422abd739e",
-        "is_secret": false,
+        "hashed_secret": "f09dd6e359833a12f48c4c4255d6e87a6e55cfe9",
         "is_verified": false,
-        "line_number": 58,
+        "line_number": 59,
         "type": "Secret Keyword"
       }
     ],
@@ -111,21 +110,20 @@
         "hashed_secret": "2546383b95bb44732e9be6a877fd476c0442fdab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 48,
+        "line_number": 49,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "d84ce25b0f9bc2cc263006ae39453efb22cc2900",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 50,
+        "line_number": 51,
         "type": "Secret Keyword"
       },
       {
-        "hashed_secret": "abb751db44bcfd1bb9d4ad53e40138422abd739e",
-        "is_secret": false,
+        "hashed_secret": "f09dd6e359833a12f48c4c4255d6e87a6e55cfe9",
         "is_verified": false,
-        "line_number": 77,
+        "line_number": 78,
         "type": "Secret Keyword"
       }
     ],
@@ -342,21 +340,20 @@
         "hashed_secret": "2546383b95bb44732e9be6a877fd476c0442fdab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 40,
+        "line_number": 41,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "d84ce25b0f9bc2cc263006ae39453efb22cc2900",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 42,
+        "line_number": 43,
         "type": "Secret Keyword"
       },
       {
-        "hashed_secret": "abb751db44bcfd1bb9d4ad53e40138422abd739e",
-        "is_secret": false,
+        "hashed_secret": "f09dd6e359833a12f48c4c4255d6e87a6e55cfe9",
         "is_verified": false,
-        "line_number": 60,
+        "line_number": 61,
         "type": "Secret Keyword"
       }
     ],
@@ -392,21 +389,20 @@
         "hashed_secret": "2546383b95bb44732e9be6a877fd476c0442fdab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 51,
+        "line_number": 52,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "d84ce25b0f9bc2cc263006ae39453efb22cc2900",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 53,
+        "line_number": 54,
         "type": "Secret Keyword"
       },
       {
-        "hashed_secret": "abb751db44bcfd1bb9d4ad53e40138422abd739e",
-        "is_secret": false,
+        "hashed_secret": "f09dd6e359833a12f48c4c4255d6e87a6e55cfe9",
         "is_verified": false,
-        "line_number": 78,
+        "line_number": 79,
         "type": "Secret Keyword"
       }
     ],
@@ -415,21 +411,20 @@
         "hashed_secret": "2546383b95bb44732e9be6a877fd476c0442fdab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 40,
+        "line_number": 41,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "d84ce25b0f9bc2cc263006ae39453efb22cc2900",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 42,
+        "line_number": 43,
         "type": "Secret Keyword"
       },
       {
-        "hashed_secret": "abb751db44bcfd1bb9d4ad53e40138422abd739e",
-        "is_secret": false,
+        "hashed_secret": "f09dd6e359833a12f48c4c4255d6e87a6e55cfe9",
         "is_verified": false,
-        "line_number": 60,
+        "line_number": 61,
         "type": "Secret Keyword"
       }
     ],
@@ -508,13 +503,13 @@
       {
         "hashed_secret": "08eeb737b239bdb7362a875b90e22c10b8826b20",
         "is_verified": false,
-        "line_number": 418,
+        "line_number": 417,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "eb9739c6625f06b4ab73035223366dda6262ae77",
         "is_verified": false,
-        "line_number": 421,
+        "line_number": 420,
         "type": "Base64 High Entropy String"
       }
     ],
@@ -523,21 +518,20 @@
         "hashed_secret": "2546383b95bb44732e9be6a877fd476c0442fdab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 49,
+        "line_number": 50,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "d84ce25b0f9bc2cc263006ae39453efb22cc2900",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 51,
+        "line_number": 52,
         "type": "Secret Keyword"
       },
       {
-        "hashed_secret": "abb751db44bcfd1bb9d4ad53e40138422abd739e",
-        "is_secret": false,
+        "hashed_secret": "f09dd6e359833a12f48c4c4255d6e87a6e55cfe9",
         "is_verified": false,
-        "line_number": 72,
+        "line_number": 73,
         "type": "Secret Keyword"
       }
     ],
@@ -578,21 +572,20 @@
         "hashed_secret": "2546383b95bb44732e9be6a877fd476c0442fdab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 56,
+        "line_number": 57,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "d84ce25b0f9bc2cc263006ae39453efb22cc2900",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 58,
+        "line_number": 59,
         "type": "Secret Keyword"
       },
       {
-        "hashed_secret": "abb751db44bcfd1bb9d4ad53e40138422abd739e",
-        "is_secret": false,
+        "hashed_secret": "f09dd6e359833a12f48c4c4255d6e87a6e55cfe9",
         "is_verified": false,
-        "line_number": 80,
+        "line_number": 81,
         "type": "Secret Keyword"
       }
     ],
@@ -662,21 +655,20 @@
         "hashed_secret": "2546383b95bb44732e9be6a877fd476c0442fdab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 38,
+        "line_number": 39,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "d84ce25b0f9bc2cc263006ae39453efb22cc2900",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 40,
+        "line_number": 41,
         "type": "Secret Keyword"
       },
       {
-        "hashed_secret": "abb751db44bcfd1bb9d4ad53e40138422abd739e",
-        "is_secret": false,
+        "hashed_secret": "f09dd6e359833a12f48c4c4255d6e87a6e55cfe9",
         "is_verified": false,
-        "line_number": 66,
+        "line_number": 67,
         "type": "Secret Keyword"
       }
     ],
@@ -689,12 +681,11 @@
         "type": "Secret Keyword"
       }
     ],
-    "sample-values/values_aws_dev.yaml": [
+    "sample-values/values_local_dev.yaml": [
       {
-        "hashed_secret": "9b5925ea817163740dfb287a9894e8ab3aba2c18",
-        "is_secret": false,
+        "hashed_secret": "db2e3619772c67cb47128ab5111584c51db38510",
         "is_verified": false,
-        "line_number": 34,
+        "line_number": 25,
         "type": "Secret Keyword"
       }
     ],

--- a/docs/portal/Dockerfile
+++ b/docs/portal/Dockerfile
@@ -37,6 +37,7 @@ FROM nginx:latest
 
 COPY overrides/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /data-portal/build/*.js /data-portal/build/index.html /usr/share/nginx/html/
+COPY --from=builder /data-portal/data /usr/share/nginx/html/data
 COPY --from=builder /data-portal/src/img/ /usr/share/nginx/html/src/img/
 COPY --from=builder /data-portal/src/css/ /usr/share/nginx/html/src/css/
 

--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -52,7 +52,7 @@ dependencies:
   repository: "file://../metadata"
   condition: metadata.enabled
 - name: peregrine
-  version: "0.1.4"
+  version: "0.1.5"
   repository: "file://../peregrine"
   condition: peregrine.enabled
 - name: pidgin
@@ -60,7 +60,7 @@ dependencies:
   repository: "file://../pidgin"
   condition: pidgin.enabled
 - name: portal
-  version: "0.1.1"
+  version: "0.1.2"
   repository: "file://../portal"
   condition: portal.enabled
 - name: requestor
@@ -68,7 +68,7 @@ dependencies:
   repository: "file://../requestor"
   condition: requestor.enabled
 - name: revproxy
-  version: "0.1.3"
+  version: "0.1.4"
   repository: "file://../revproxy"
   condition: revproxy.enabled
 - name: sheepdog

--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
   repository: "file://../ambassador"
   condition: ambassador.enabled
 - name: arborist
-  version: "0.1.3"
+  version: "0.1.4"
   repository: "file://../arborist"
   condition: arborist.enabled
 - name: argo-wrapper
@@ -17,7 +17,7 @@ dependencies:
   repository: "file://../argo-wrapper"
   condition: argo-wrapper.enabled
 - name: audit
-  version: "0.1.3"
+  version: "0.1.4"
   repository: "file://../audit"
   condition: audit.enabled
 - name: aws-es-proxy
@@ -28,7 +28,7 @@ dependencies:
   version: 0.1.3
   repository: file://../common
 - name: fence
-  version: "0.1.3"
+  version: "0.1.4"
   repository: "file://../fence"
   condition: fence.enabled
 - name: guppy
@@ -40,7 +40,7 @@ dependencies:
   repository: "file://../hatchery"
   condition: hatchery.enabled
 - name: indexd
-  version: "0.1.3"
+  version: "0.1.4"
   repository: "file://../indexd"
   condition: indexd.enabled
 - name: manifestservice
@@ -48,11 +48,11 @@ dependencies:
   repository: "file://../manifestservice"
   condition: manifestservice.enabled
 - name: metadata
-  version: "0.1.3"
+  version: "0.1.4"
   repository: "file://../metadata"
   condition: metadata.enabled
 - name: peregrine
-  version: "0.1.3"
+  version: "0.1.4"
   repository: "file://../peregrine"
   condition: peregrine.enabled
 - name: pidgin
@@ -64,7 +64,7 @@ dependencies:
   repository: "file://../portal"
   condition: portal.enabled
 - name: requestor
-  version: "0.1.3"
+  version: "0.1.4"
   repository: "file://../requestor"
   condition: requestor.enabled
 - name: revproxy
@@ -72,7 +72,7 @@ dependencies:
   repository: "file://../revproxy"
   condition: revproxy.enabled
 - name: sheepdog
-  version: "0.1.3"
+  version: "0.1.4"
   repository: "file://../sheepdog"
   condition: sheepdog.enabled
 - name: ssjdispatcher
@@ -80,7 +80,7 @@ dependencies:
   repository: "file://../ssjdispatcher"
   condition: ssjdispatcher.enabled
 - name: wts
-  version: "0.1.4"
+  version: "0.1.5"
   repository: "file://../wts"
   condition: wts.enabled
 
@@ -107,7 +107,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/gen3/README.md
+++ b/helm/gen3/README.md
@@ -1,6 +1,6 @@
 # gen3
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 Helm chart to deploy Gen3 Data Commons
 
@@ -19,26 +19,26 @@ Helm chart to deploy Gen3 Data Commons
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../ambassador | ambassador | 0.1.3 |
-| file://../arborist | arborist | 0.1.3 |
+| file://../arborist | arborist | 0.1.4 |
 | file://../argo-wrapper | argo-wrapper | 0.1.0 |
-| file://../audit | audit | 0.1.3 |
+| file://../audit | audit | 0.1.4 |
 | file://../aws-es-proxy | aws-es-proxy | 0.1.2 |
 | file://../common | common | 0.1.3 |
 | file://../elasticsearch | elasticsearch | 0.1.1 |
-| file://../fence | fence | 0.1.3 |
+| file://../fence | fence | 0.1.4 |
 | file://../guppy | guppy | 0.1.3 |
 | file://../hatchery | hatchery | 0.1.2 |
-| file://../indexd | indexd | 0.1.3 |
+| file://../indexd | indexd | 0.1.4 |
 | file://../manifestservice | manifestservice | 0.1.2 |
-| file://../metadata | metadata | 0.1.3 |
-| file://../peregrine | peregrine | 0.1.3 |
+| file://../metadata | metadata | 0.1.4 |
+| file://../peregrine | peregrine | 0.1.4 |
 | file://../pidgin | pidgin | 0.1.3 |
 | file://../portal | portal | 0.1.1 |
-| file://../requestor | requestor | 0.1.3 |
+| file://../requestor | requestor | 0.1.4 |
 | file://../revproxy | revproxy | 0.1.3 |
-| file://../sheepdog | sheepdog | 0.1.3 |
+| file://../sheepdog | sheepdog | 0.1.4 |
 | file://../ssjdispatcher | ssjdispatcher | 0.1.1 |
-| file://../wts | wts | 0.1.4 |
+| file://../wts | wts | 0.1.5 |
 | https://charts.bitnami.com/bitnami | postgresql | 11.9.13 |
 
 ## Values

--- a/helm/gen3/README.md
+++ b/helm/gen3/README.md
@@ -31,11 +31,11 @@ Helm chart to deploy Gen3 Data Commons
 | file://../indexd | indexd | 0.1.4 |
 | file://../manifestservice | manifestservice | 0.1.2 |
 | file://../metadata | metadata | 0.1.4 |
-| file://../peregrine | peregrine | 0.1.4 |
+| file://../peregrine | peregrine | 0.1.5 |
 | file://../pidgin | pidgin | 0.1.3 |
-| file://../portal | portal | 0.1.1 |
+| file://../portal | portal | 0.1.2 |
 | file://../requestor | requestor | 0.1.4 |
-| file://../revproxy | revproxy | 0.1.3 |
+| file://../revproxy | revproxy | 0.1.4 |
 | file://../sheepdog | sheepdog | 0.1.4 |
 | file://../ssjdispatcher | ssjdispatcher | 0.1.1 |
 | file://../wts | wts | 0.1.5 |

--- a/helm/peregrine/Chart.yaml
+++ b/helm/peregrine/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "master"
+appVersion: "2023.01"
 
 
 dependencies:

--- a/helm/peregrine/README.md
+++ b/helm/peregrine/README.md
@@ -1,6 +1,6 @@
 # peregrine
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2023.01](https://img.shields.io/badge/AppVersion-2023.01-informational?style=flat-square)
 
 A Helm chart for gen3 Peregrine service
 

--- a/helm/peregrine/templates/deployment.yaml
+++ b/helm/peregrine/templates/deployment.yaml
@@ -141,7 +141,7 @@ spec:
           volumeMounts:
             - name: "config-volume"
               readOnly: true
-              mountPath: "/var/www/peregrine/settings.py"
+              mountPath: "/var/www/peregrine/wsgi.py"
               subPath: "settings.py"
           ports:
             - name: http

--- a/helm/portal/Chart.yaml
+++ b/helm/portal/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/portal/README.md
+++ b/helm/portal/README.md
@@ -1,6 +1,6 @@
 # portal
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for gen3 data-portal
 
@@ -53,8 +53,8 @@ A Helm chart for gen3 data-portal
 | global.tierAccessLevel | string | `"libre"` | Access level for tiers. |
 | global.userYamlS3Path | string | `"s3://cdis-gen3-users/test/user.yaml"` | Path to the user.yaml file in S3. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"quay.io/cdis/data-portal-prebuilt"` |  |
-| image.tag | string | `"brh.data-commons.org-feat-develop"` |  |
+| image.repository | string | `"quay.io/cdis/data-portal"` |  |
+| image.tag | string | `"master"` |  |
 | imagePullSecrets | list | `[]` |  |
 | labels.app | string | `"portal"` |  |
 | labels.public | string | `"yes"` |  |
@@ -64,10 +64,9 @@ A Helm chart for gen3 data-portal
 | podSecurityContext | object | `{}` |  |
 | portalApp | string | `"gitops"` |  |
 | replicaCount | int | `1` |  |
-| resources.limits.cpu | float | `2` |  |
 | resources.limits.memory | string | `"4096Mi"` |  |
-| resources.requests.cpu | float | `0.6` |  |
-| resources.requests.memory | string | `"512Mi"` |  |
+| resources.requests.cpu | float | `2` |  |
+| resources.requests.memory | string | `"4096Mi"` |  |
 | revisionHistoryLimit | int | `2` |  |
 | securityContext | object | `{}` |  |
 | selectorLabels.app | string | `"portal"` |  |

--- a/helm/portal/templates/deployment.yaml
+++ b/helm/portal/templates/deployment.yaml
@@ -52,7 +52,8 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 60
             timeoutSeconds: 30
-            # TODO: re-add resources
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
           ports:
             - containerPort: 80
             - containerPort: 443

--- a/helm/portal/values.yaml
+++ b/helm/portal/values.yaml
@@ -59,10 +59,10 @@ global:
 replicaCount: 1
 
 image:
-  repository: quay.io/cdis/data-portal-prebuilt
+  repository: quay.io/cdis/data-portal
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "brh.data-commons.org-feat-develop"
+  tag: "master"
 
 
 imagePullSecrets: []
@@ -139,10 +139,9 @@ automountServiceAccountToken: false
 
 resources:
   requests:
-    cpu: 0.6
-    memory: 512Mi
-  limits:
     cpu: 2.0
+    memory: 4096Mi
+  limits:
     memory: 4096Mi
 
 portalApp: "gitops"

--- a/helm/revproxy/Chart.yaml
+++ b/helm/revproxy/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/revproxy/README.md
+++ b/helm/revproxy/README.md
@@ -1,6 +1,6 @@
 # revproxy
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for gen3 revproxy
 

--- a/helm/revproxy/nginx/nginx.conf
+++ b/helm/revproxy/nginx/nginx.conf
@@ -66,7 +66,7 @@ http {
   # #   on demand: https://www.nginx.com/blog/introduction-nginscript/
   # # #
   js_import helpers.js;
-  js_set $userid userid;
+  js_set $userid helpers.userid;
   
 
   perl_set $document_url_env 'sub { return $ENV{"DOCUMENT_URL"} || ""; }';


### PR DESCRIPTION
### New Features


### Breaking Changes


### Bug Fixes
- Fix https://github.com/uc-cdis/gen3-helm/issues/102 
- Fix https://github.com/uc-cdis/gen3-helm/issues/101 by reverting to portal to build at runtime, and updating documentation to include this in prebuilt images. 
- Pin peregrine to 2023.01 as latest changes are not compatible with helm. 
- Added resources to portal, as portal now requires a lot of CPU/Memory to start

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
