### PR TITLE
correcting selector label mismatch for the manifestservice

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-03-16T15:47:51Z",
+  "generated_at": "2023-03-16T19:37:11Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -413,7 +413,7 @@
         "hashed_secret": "611f2e9064b518afdb23f201321f39029dd28917",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 54,
+        "line_number": 56,
         "type": "Secret Keyword"
       }
     ],

--- a/helm/manifestservice/Chart.yaml
+++ b/helm/manifestservice/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/manifestservice/Chart.yaml
+++ b/helm/manifestservice/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/manifestservice/README.md
+++ b/helm/manifestservice/README.md
@@ -1,6 +1,6 @@
 # manifestservice
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -39,6 +39,8 @@ A Helm chart for Kubernetes
 | resources.requests.cpu | string | `0.1` | The amount of CPU requested |
 | resources.requests.memory | string | `"12Mi"` | The amount of memory requested |
 | revisionHistoryLimit | int | `2` | Number of old revisions to retain |
+| selectorLabels.app | string | `"manifestservice"` |  |
+| selectorLabels.release | string | `"production"` |  |
 | service | map | `{"port":80,"type":"ClusterIP"}` | Kubernetes service information. |
 | service.port | int | `80` | The port number that the service exposes. |
 | service.type | string | `"ClusterIP"` | Type of service. Valid values are "ClusterIP", "NodePort", "LoadBalancer", "ExternalName". |

--- a/helm/manifestservice/README.md
+++ b/helm/manifestservice/README.md
@@ -1,6 +1,6 @@
 # manifestservice
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/helm/manifestservice/templates/deployment.yaml
+++ b/helm/manifestservice/templates/deployment.yaml
@@ -15,8 +15,7 @@ spec:
       labels:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-        app: manifestservice
-        release: production
+        {{- include "manifestservice.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.affinity }}
       affinity:

--- a/helm/manifestservice/values.yaml
+++ b/helm/manifestservice/values.yaml
@@ -2,6 +2,10 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+selectorLabels:
+  app: manifestservice
+  release: production
+
 # -- (int) Number of old revisions to retain
 revisionHistoryLimit: 2
 


### PR DESCRIPTION
Labels were slightly off, causing the manifest service to throw the following error: 
helm `selector` does not match template `labels`

The selector labels did not match the template labels, so the manifest service could not be deployed. 