### PR TITLE
Update workflow to use GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/lint_test.yaml
+++ b/.github/workflows/lint_test.yaml
@@ -29,7 +29,7 @@ jobs:
         run: |
           changed=$(ct list-changed --config .github/ct.yaml)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true >> $GITHUB_OUTPUT"
           fi
 
       - name: Run chart-testing (lint)


### PR DESCRIPTION
Jira Ticket: [PXP-10933](https://ctds-planx.atlassian.net/browse/PXP-10933)
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes
Github workflow updated to use GITBHUB_OUTPUT, set-output deprecated

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->

[PXP-10933]: https://ctds-planx.atlassian.net/browse/PXP-10933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ