### PR TITLE
allowing the "imagePullPolicy" to be configurable for these charts.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-06-05T18:40:35Z",
+  "generated_at": "2023-07-03T15:16:07Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -491,7 +491,7 @@
         "hashed_secret": "611f2e9064b518afdb23f201321f39029dd28917",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 70,
+        "line_number": 74,
         "type": "Secret Keyword"
       }
     ],

--- a/helm/fence/Chart.yaml
+++ b/helm/fence/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.12
+version: 0.1.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/fence/README.md
+++ b/helm/fence/README.md
@@ -1,6 +1,6 @@
 # fence
 
-![Version: 0.1.12](https://img.shields.io/badge/Version-0.1.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for gen3 Fence
 

--- a/helm/fence/templates/fence-deployment.yaml
+++ b/helm/fence/templates/fence-deployment.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
         - name: fence
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
               containerPort: 80

--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
   version: "0.1.7"
   repository: file://../common
 - name: fence
-  version: "0.1.12"
+  version: "0.1.13"
   repository: "file://../fence"
   condition: fence.enabled
 - name: guppy
@@ -44,7 +44,7 @@ dependencies:
   repository: "file://../indexd"
   condition: indexd.enabled
 - name: manifestservice
-  version: "0.1.9"
+  version: "0.1.10"
   repository: "file://../manifestservice"
   condition: manifestservice.enabled
 - name: metadata
@@ -72,11 +72,11 @@ dependencies:
   repository: "file://../revproxy"
   condition: revproxy.enabled
 - name: sheepdog
-  version: "0.1.10"
+  version: "0.1.11"
   repository: "file://../sheepdog"
   condition: sheepdog.enabled
 - name: ssjdispatcher
-  version: "0.1.5"
+  version: "0.1.6"
   repository: "file://../ssjdispatcher"
   condition: ssjdispatcher.enabled
 - name: wts
@@ -107,7 +107,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.17
+version: 0.1.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -72,7 +72,7 @@ dependencies:
   repository: "file://../revproxy"
   condition: revproxy.enabled
 - name: sheepdog
-  version: "0.1.11"
+  version: "0.1.10"
   repository: "file://../sheepdog"
   condition: sheepdog.enabled
 - name: ssjdispatcher

--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -107,7 +107,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.19
+version: 0.1.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -107,7 +107,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.18
+version: 0.1.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/gen3/README.md
+++ b/helm/gen3/README.md
@@ -1,6 +1,6 @@
 # gen3
 
-![Version: 0.1.17](https://img.shields.io/badge/Version-0.1.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.18](https://img.shields.io/badge/Version-0.1.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 Helm chart to deploy Gen3 Data Commons
 
@@ -25,19 +25,19 @@ Helm chart to deploy Gen3 Data Commons
 | file://../aws-es-proxy | aws-es-proxy | 0.1.6 |
 | file://../common | common | 0.1.7 |
 | file://../elasticsearch | elasticsearch | 0.1.5 |
-| file://../fence | fence | 0.1.12 |
+| file://../fence | fence | 0.1.13 |
 | file://../guppy | guppy | 0.1.8 |
 | file://../hatchery | hatchery | 0.1.6 |
 | file://../indexd | indexd | 0.1.10 |
-| file://../manifestservice | manifestservice | 0.1.9 |
+| file://../manifestservice | manifestservice | 0.1.10 |
 | file://../metadata | metadata | 0.1.8 |
 | file://../peregrine | peregrine | 0.1.9 |
 | file://../pidgin | pidgin | 0.1.7 |
 | file://../portal | portal | 0.1.7 |
 | file://../requestor | requestor | 0.1.8 |
 | file://../revproxy | revproxy | 0.1.10 |
-| file://../sheepdog | sheepdog | 0.1.10 |
-| file://../ssjdispatcher | ssjdispatcher | 0.1.5 |
+| file://../sheepdog | sheepdog | 0.1.11 |
+| file://../ssjdispatcher | ssjdispatcher | 0.1.6 |
 | file://../wts | wts | 0.1.10 |
 | https://charts.bitnami.com/bitnami | postgresql | 11.9.13 |
 

--- a/helm/gen3/README.md
+++ b/helm/gen3/README.md
@@ -36,7 +36,7 @@ Helm chart to deploy Gen3 Data Commons
 | file://../portal | portal | 0.1.7 |
 | file://../requestor | requestor | 0.1.8 |
 | file://../revproxy | revproxy | 0.1.10 |
-| file://../sheepdog | sheepdog | 0.1.11 |
+| file://../sheepdog | sheepdog | 0.1.10 |
 | file://../ssjdispatcher | ssjdispatcher | 0.1.6 |
 | file://../wts | wts | 0.1.10 |
 | https://charts.bitnami.com/bitnami | postgresql | 11.9.13 |

--- a/helm/gen3/README.md
+++ b/helm/gen3/README.md
@@ -1,6 +1,6 @@
 # gen3
 
-![Version: 0.1.18](https://img.shields.io/badge/Version-0.1.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.19](https://img.shields.io/badge/Version-0.1.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 Helm chart to deploy Gen3 Data Commons
 

--- a/helm/gen3/README.md
+++ b/helm/gen3/README.md
@@ -1,6 +1,6 @@
 # gen3
 
-![Version: 0.1.19](https://img.shields.io/badge/Version-0.1.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.18](https://img.shields.io/badge/Version-0.1.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 Helm chart to deploy Gen3 Data Commons
 

--- a/helm/manifestservice/Chart.yaml
+++ b/helm/manifestservice/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.9
+version: 0.1.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/manifestservice/README.md
+++ b/helm/manifestservice/README.md
@@ -1,6 +1,6 @@
 # manifestservice
 
-![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -38,6 +38,10 @@ A Helm chart for Kubernetes
 | global.environment | string | `"default"` | Environment name. This should be the same as vpcname if you're doing an AWS deployment. Currently this is being used to share ALB's if you have multiple namespaces. Might be used other places too. |
 | global.minAvialable | int | `1` | The minimum amount of pods that are available at all times if the PDB is deployed. |
 | global.pdb | bool | `false` | If the service will be deployed with a Pod Disruption Budget. Note- you need to have more than 2 replicas for the pdb to be deployed. |
+| image | map | `{"pullPolicy":"Always","repository":"quay.io/cdis/manifestservice","tag":"2022.09"}` | Docker image information. |
+| image.pullPolicy | string | `"Always"` | Docker pull policy. |
+| image.repository | string | `"quay.io/cdis/manifestservice"` | Docker repository. |
+| image.tag | string | `"2022.09"` | Overrides the image tag whose default is the chart appVersion. |
 | manifestserviceG3auto | map | `{"awsaccesskey":"","awssecretkey":"","bucketName":"testbucket","hostname":"testinstall","prefix":"test"}` | Values for manifestservice secret. |
 | manifestserviceG3auto.awsaccesskey | string | `""` | AWS access key. |
 | manifestserviceG3auto.awssecretkey | string | `""` | AWS secret access key. |

--- a/helm/manifestservice/templates/deployment.yaml
+++ b/helm/manifestservice/templates/deployment.yaml
@@ -38,8 +38,8 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds}}
       containers:
         - name: manifestservice
-          image: "quay.io/cdis/manifestservice:2022.09"
-          imagePullPolicy: Always
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             {{- if .Values.global.ddEnabled }}
             {{- include "common.datadogEnvVar" . | nindent 12 }}

--- a/helm/manifestservice/values.yaml
+++ b/helm/manifestservice/values.yaml
@@ -19,6 +19,15 @@ revisionHistoryLimit: 2
 # -- (int) Number of replicas for the deployment.
 replicaCount: 1
 
+# -- (map) Docker image information.
+image:
+  # -- (string) Docker repository.
+  repository: quay.io/cdis/manifestservice
+  # -- (string) Docker pull policy.
+  pullPolicy: Always
+  # -- (string) Overrides the image tag whose default is the chart appVersion.
+  tag: "2022.09"
+
 # -- (map) Kubernetes service information.
 service:
   # -- (string) Type of service. Valid values are "ClusterIP", "NodePort", "LoadBalancer", "ExternalName".

--- a/helm/sower/Chart.yaml
+++ b/helm/sower/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/sower/README.md
+++ b/helm/sower/README.md
@@ -1,6 +1,6 @@
 # sower
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for gen3 sower
 

--- a/helm/sower/templates/deployment.yaml
+++ b/helm/sower/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
         - name: sower
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
             {{- toYaml .Values.volumeMounts | nindent 12 }}
           env:

--- a/helm/ssjdispatcher/Chart.yaml
+++ b/helm/ssjdispatcher/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/ssjdispatcher/README.md
+++ b/helm/ssjdispatcher/README.md
@@ -1,6 +1,6 @@
 # ssjdispatcher
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for gen3 ssjdispatcher
 
@@ -64,10 +64,10 @@ A Helm chart for gen3 ssjdispatcher
 | global.publicDataSets | bool | `true` | Whether public datasets are enabled. |
 | global.revproxyArn | string | `"arn:aws:acm:us-east-1:123456:certificate"` | ARN of the reverse proxy certificate. |
 | global.tierAccessLevel | string | `"libre"` | Access level for tiers. acceptable values for `tier_access_level` are: `libre`, `regular` and `private`. If omitted, by default common will be treated as `private` |
-| image | map | `{"pullPolicy":"IfNotPresent","repository":"nginx","tag":""}` | Docker image information. |
-| image.pullPolicy | string | `"IfNotPresent"` | Docker pull policy. |
-| image.repository | string | `"nginx"` | Docker repository. |
-| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| image | map | `{"pullPolicy":"Always","repository":"quay.io/cdis/ssjdispatcher","tag":"2022.08"}` | Docker image information. |
+| image.pullPolicy | string | `"Always"` | Docker pull policy. |
+| image.repository | string | `"quay.io/cdis/ssjdispatcher"` | Docker repository. |
+| image.tag | string | `"2022.08"` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Docker image pull secrets. |
 | indexing | string | `"707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexs3client:2022.08"` | Image to use for the "indexing" job. |
 | nameOverride | string | `""` | Override the name of the chart. |

--- a/helm/ssjdispatcher/templates/deployment.yaml
+++ b/helm/ssjdispatcher/templates/deployment.yaml
@@ -36,8 +36,8 @@ spec:
         {{- toYaml .Values.volumes | nindent 8 }}
       containers:
         - name: ssjdispatcher
-          image: "quay.io/cdis/ssjdispatcher:2022.08"
-          imagePullPolicy: Always
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
             {{- toYaml .Values.volumeMounts | nindent 12 }}
           env:

--- a/helm/ssjdispatcher/values.yaml
+++ b/helm/ssjdispatcher/values.yaml
@@ -63,11 +63,11 @@ replicaCount: 1
 # -- (map) Docker image information.
 image:
   # -- (string) Docker repository.
-  repository: nginx
+  repository: quay.io/cdis/ssjdispatcher
   # -- (string) Docker pull policy.
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   # -- (string) Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "2022.08"
 
 # -- (list) Docker image pull secrets.
 imagePullSecrets: []


### PR DESCRIPTION
The image pull policy was hardcoded for the following charts: 
- Fence
- Manifest Service
- Sheepdog
- Sower
- SSJdispatcher

I have corrected this issue to allow for customization. 