### PR TITLE
Add opt-in Neuvector Security-as-Code Templates

### DIFF
--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -92,7 +92,6 @@ dependencies:
   repository: "file://../wts"
   condition: wts.enabled
 
-
 - name: elasticsearch
   version: 7.10.2
   repository: "https://helm.elastic.co"
@@ -101,6 +100,16 @@ dependencies:
   version: 11.9.13
   repository: "https://charts.bitnami.com/bitnami"
   condition: global.dev
+
+# (optional) NeuVector Kubernetes Security Policy templates to protect Gen3
+#   NeuVector must be installed separately.
+#   Reference: https://open-docs.neuvector.com/basics/overview
+#   Reference: https://github.com/neuvector/neuvector-helm
+# For more information, please use the Gen3 community Slack.
+- name: neuvector
+  version: "0.1.0"
+  repository: "file://../neuvector"
+  condition: neuvector.enabled
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/helm/gen3/values.yaml
+++ b/helm/gen3/values.yaml
@@ -399,3 +399,27 @@ elasticsearch:
   esConfig:
     elasticsearch.yml: |
       # Here we can add elasticsearch config
+
+# (optional) NeuVector Kubernetes Security Policy templates to protect Gen3
+#   NeuVector must be installed separately.
+#   Reference: https://open-docs.neuvector.com/basics/overview
+#   Reference: https://github.com/neuvector/neuvector-helm
+# For more information, please use the Gen3 community Slack.
+neuvector:
+  # install Neuvector
+  enabled: false
+  policies:
+    # deploy predefined Neuvector policies for Gen3
+    include: false
+    # Discover, Monitor, or Protect
+    policyMode: Monitor
+  # Configure your ingress controller information for enabling ingress to containers
+  ingress:
+    # service name of your ingress controller
+    controller: nginx-ingress-controller
+    # installation namespace of your ingress controller
+    namespace: nginx
+    # classname of your ingress
+    class: nginx
+  # Required to allow egress to in-cluster database or external, managed database
+  DB_HOST: development-gen3-postgresql

--- a/helm/gen3/values.yaml
+++ b/helm/gen3/values.yaml
@@ -423,3 +423,5 @@ neuvector:
     class: nginx
   # Required to allow egress to in-cluster database or external, managed database
   DB_HOST: development-gen3-postgresql
+  # hostname/service name for our ElasitcSearch instance, used to allow egress from containers
+  ES_HOST: gen3-elasticsearch-master

--- a/helm/neuvector/.helmignore
+++ b/helm/neuvector/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/neuvector/Chart.yaml
+++ b/helm/neuvector/Chart.yaml
@@ -1,0 +1,34 @@
+apiVersion: v2
+name: neuvector
+description: NeuVector Kubernetes Security Policy templates to protect Gen3
+
+# NeuVector must be installed separately.
+#   Reference: https://open-docs.neuvector.com/basics/overview
+#   Reference: https://github.com/neuvector/neuvector-helm
+# For more information, please use the Gen3 community Slack.
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"
+
+# Todo: Evaluate inclusion of NeuVector installation
+# dependencies:
+# - name: neuvector
+#   version: "5.2.2-s1"
+#   repository: "https://neuvector.github.io/neuvector-helm/core"

--- a/helm/neuvector/templates/_helpers.tpl
+++ b/helm/neuvector/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "neuvector.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "neuvector.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "neuvector.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "neuvector.labels" -}}
+helm.sh/chart: {{ include "neuvector.chart" . }}
+{{ include "neuvector.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "neuvector.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "neuvector.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "neuvector.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "neuvector.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/neuvector/templates/ambassador-nvsecurityrule.yaml
+++ b/helm/neuvector/templates/ambassador-nvsecurityrule.yaml
@@ -1,0 +1,212 @@
+{{- if .Values.policies.include }}
+apiVersion: neuvector.com/v1
+kind: NvSecurityRule
+metadata:
+  name: nv.ambassador-deployment.{{ .Release.Namespace }}
+spec:
+  dlp:
+    settings: []
+    status: true
+  egress:
+  - action: allow
+    applications:
+    - DNS
+    name: nv.kube-dns.kube-system-egress-0
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: kube-dns.kube-system
+      - key: domain
+        op: =
+        value: kube-system
+      name: nv.kube-dns.kube-system
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: external-egress-1
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria: []
+      name: external
+      original_name: ""
+  file: []
+  ingress:
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.ambassador-deployment.{{ .Release.Namespace }}-ingress-6
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      name: Workload:ingress
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: nv.ambassador-deployment.{{ .Release.Namespace }}-ingress-7
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: hatchery-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.hatchery-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: nv.ambassador-deployment.{{ .Release.Namespace }}-ingress-8
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria: []
+      name: external
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.ambassador-deployment.{{ .Release.Namespace }}-ingress-9
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: revproxy-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.revproxy-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - any
+    name: nv.ambassador-deployment.{{ .Release.Namespace }}-ingress-10
+    ports: tcp/8080
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: revproxy-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.revproxy-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  process:
+  - action: allow
+    allow_update: false
+    name: ambex
+    path: /opt/ambassador/bin/ambassador
+  - action: allow
+    allow_update: false
+    name: bash
+    path: /bin/bash
+  - action: allow
+    allow_update: false
+    name: busybox
+    path: /bin/busybox
+  - action: allow
+    allow_update: false
+    name: curl
+    path: /usr/bin/curl
+  - action: allow
+    allow_update: false
+    name: date
+    path: /bin/busybox
+  - action: allow
+    allow_update: false
+    name: diagd
+    path: /usr/bin/python3.7
+  - action: allow
+    allow_update: false
+    name: env
+    path: /bin/busybox
+  - action: allow
+    allow_update: false
+    name: envoy
+    path: /usr/local/bin/envoy
+  - action: allow
+    allow_update: false
+    name: find
+    path: /bin/busybox
+  - action: allow
+    allow_update: false
+    name: grep
+    path: /bin/busybox
+  - action: allow
+    allow_update: false
+    name: mkdir
+    path: /bin/busybox
+  - action: allow
+    allow_update: false
+    name: pause
+    path: /pause
+  - action: allow
+    allow_update: false
+    name: python
+    path: /usr/bin/python3.7
+  - action: allow
+    allow_update: false
+    name: python3
+    path: /usr/bin/python3.7
+  - action: allow
+    allow_update: false
+    name: sh
+    path: /bin/busybox
+  - action: allow
+    allow_update: false
+    name: sleep
+    path: /bin/busybox
+  - action: allow
+    allow_update: false
+    name: sort
+    path: /bin/busybox
+  - action: allow
+    allow_update: false
+    name: uname
+    path: /bin/busybox
+  - action: allow
+    allow_update: false
+    name: watt
+    path: /opt/ambassador/bin/ambassador
+  - action: allow
+    allow_update: false
+    name: wc
+    path: /bin/busybox
+  process_profile:
+    baseline: zero-drift
+  target:
+    policymode: {{ .Values.policies.policyMode }}
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: ambassador-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.ambassador-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  waf:
+    settings: []
+    status: true
+{{- end }}

--- a/helm/neuvector/templates/arborist-nvsecurityrule.yaml
+++ b/helm/neuvector/templates/arborist-nvsecurityrule.yaml
@@ -1,0 +1,218 @@
+{{- if .Values.policies.include }}
+apiVersion: neuvector.com/v1
+kind: NvSecurityRule
+metadata:
+  name: nv.arborist-deployment.{{ .Release.Namespace }}
+spec:
+  dlp:
+    settings: []
+    status: true
+  egress:
+  - action: allow
+    applications:
+    - DNS
+    name: nv.kube-dns.kube-system-egress-7
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: kube-dns.kube-system
+      - key: domain
+        op: =
+        value: kube-system
+      name: nv.kube-dns.kube-system
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.fence-deployment.{{ .Release.Namespace }}-egress-8
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: fence-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.fence-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - PostgreSQL
+    name: nv.{{ .Values.DB_HOST }}.{{ .Release.Namespace }}-egress-9
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: {{ .Values.DB_HOST }}.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.{{ .Values.DB_HOST }}.{{ .Release.Namespace }}
+      original_name: ""
+  file: []
+  ingress:
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.arborist-deployment.{{ .Release.Namespace }}-ingress-17
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      name: Workload:ingress
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.arborist-deployment.{{ .Release.Namespace }}-ingress-18
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: revproxy-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.revproxy-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: nv.arborist-deployment.{{ .Release.Namespace }}-ingress-19
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria: []
+      name: external
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.arborist-deployment.{{ .Release.Namespace }}-ingress-20
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: fence-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.fence-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.arborist-deployment.{{ .Release.Namespace }}-ingress-21
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: peregrine-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.peregrine-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.arborist-deployment.{{ .Release.Namespace }}-ingress-22
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: guppy-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.guppy-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.arborist-deployment.{{ .Release.Namespace }}-ingress-23
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: sheepdog-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.sheepdog-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: nv.arborist-deployment.{{ .Release.Namespace }}-ingress-24
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: hatchery-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.hatchery-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  process:
+  - action: allow
+    allow_update: false
+    name: arborist
+    path: /go/src/github.com/uc-cdis/arborist/bin/arborist
+  - action: allow
+    allow_update: false
+    name: pause
+    path: /pause
+  - action: allow
+    allow_update: false
+    name: sh
+    path: /bin/dash
+  process_profile:
+    baseline: zero-drift
+  target:
+    policymode: {{ .Values.policies.policyMode }}
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: arborist-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.arborist-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  waf:
+    settings: []
+    status: true
+{{- end }}

--- a/helm/neuvector/templates/audit-nvsecurityrule.yaml
+++ b/helm/neuvector/templates/audit-nvsecurityrule.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.policies.include }}
+apiVersion: neuvector.com/v1
+kind: NvSecurityRule
+metadata:
+  name: nv.audit-deployment.{{ .Release.Namespace }}
+spec:
+  dlp:
+    settings: []
+    status: true
+  egress:
+  - action: allow
+    applications:
+    - DNS
+    name: nv.kube-dns.kube-system-egress-5
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: kube-dns.kube-system
+      - key: domain
+        op: =
+        value: kube-system
+      name: nv.kube-dns.kube-system
+      original_name: ""
+  - action: allow
+    applications:
+    - PostgreSQL
+    name: nv.{{ .Values.DB_HOST }}.{{ .Release.Namespace }}-egress-6
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: {{ .Values.DB_HOST }}.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.{{ .Values.DB_HOST }}.{{ .Release.Namespace }}
+      original_name: ""
+  file: []
+  ingress:
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.audit-deployment.{{ .Release.Namespace }}-ingress-15
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      name: Workload:ingress
+      original_name: ""
+  - action: allow
+    applications:
+    - any
+    name: nv.audit-deployment.{{ .Release.Namespace }}-ingress-16
+    ports: tcp/80
+    priority: 0
+    selector:
+      comment: ""
+      name: Workload:ingress
+      original_name: ""
+  process:
+  - action: allow
+    allow_update: false
+    name: alembic
+    path: /usr/local/bin/python3.9
+  - action: allow
+    allow_update: false
+    name: gunicorn
+    path: /usr/local/bin/python3.9
+  - action: allow
+    allow_update: false
+    name: pause
+    path: /pause
+  process_profile:
+    baseline: zero-drift
+  target:
+    policymode: {{ .Values.policies.policyMode }}
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: audit-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.audit-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  waf:
+    settings: []
+    status: true
+{{- end }}

--- a/helm/neuvector/templates/elasticsearch-nvsecurityrule.yaml
+++ b/helm/neuvector/templates/elasticsearch-nvsecurityrule.yaml
@@ -1,0 +1,87 @@
+{{- if .Values.policies.include }}
+apiVersion: neuvector.com/v1
+kind: NvSecurityRule
+metadata:
+  name: nv.gen3-elasticsearch-master.{{ .Release.Namespace }}
+spec:
+  dlp:
+    settings: []
+    status: true
+  egress: []
+  file: []
+  ingress:
+  - action: allow
+    applications:
+    - any
+    name: nv.gen3-elasticsearch-master.{{ .Release.Namespace }}-ingress-39
+    ports: tcp/9200
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: revproxy-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.revproxy-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - any
+    name: nv.gen3-elasticsearch-master.{{ .Release.Namespace }}-ingress-40
+    ports: tcp/9200
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: guppy-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.guppy-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - any
+    name: nv.gen3-elasticsearch-master.{{ .Release.Namespace }}-ingress-41
+    ports: tcp/9200
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: guppy-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.guppy-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  process:
+  - action: allow
+    allow_update: false
+    name: sh
+    path: '*'
+  process_profile:
+    baseline: zero-drift
+  target:
+    policymode: {{ .Values.policies.policyMode }}
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: gen3-elasticsearch-master.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.gen3-elasticsearch-master.{{ .Release.Namespace }}
+      original_name: ""
+  waf:
+    settings: []
+    status: true
+{{- end }}

--- a/helm/neuvector/templates/etl-cronjob-nvsecurityrule.yaml
+++ b/helm/neuvector/templates/etl-cronjob-nvsecurityrule.yaml
@@ -1,0 +1,346 @@
+apiVersion: neuvector.com/v1
+kind: NvSecurityRule
+metadata:
+  name: nv.etl-cronjob-rule.{{ .Release.Namespace }}
+spec:
+  dlp:
+    settings: []
+    status: true
+  egress:
+  - action: allow
+    applications:
+    - DNS
+    name: nv.kube-dns.kube-system-egress-0
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: kube-dns.kube-system
+      - key: domain
+        op: =
+        value: kube-system
+      name: nv.kube-dns.kube-system
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.{{ .Values.ES_HOST }}.{{ .Release.Namespace }}-egress-1
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: {{ .Values.ES_HOST }}.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.{{ .Values.ES_HOST }}.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - PostgreSQL
+    name: nv.{{ .Values.DB_HOST }}.{{ .Release.Namespace }}-egress-2
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: {{ .Values.DB_HOST }}.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.{{ .Values.DB_HOST }}.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: external-egress-3
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria: []
+      name: external
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.revproxy-deployment.{{ .Release.Namespace }}-egress-4
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: revproxy-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.revproxy-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  file: []
+  ingress:
+  - action: allow
+    applications:
+    - any
+    name: nv.etl-cronjob.{{ .Release.Namespace }}-ingress-0
+    ports: tcp/9000
+    priority: 0
+    selector:
+      comment: ""
+      name: Workload:ingress
+      original_name: ""
+  process:
+  - action: allow
+    allow_update: false
+    name: basename
+    path: /usr/bin/basename
+  - action: allow
+    allow_update: false
+    name: bash
+    path: /bin/bash
+  - action: allow
+    allow_update: false
+    name: bash
+    path: /usr/bin/env
+  - action: allow
+    allow_update: false
+    name: bash
+    path: /usr/bin/setsid
+  - action: allow
+    allow_update: false
+    name: cat
+    path: /bin/cat
+  - action: allow
+    allow_update: false
+    name: chmod
+    path: /bin/chmod
+  - action: allow
+    allow_update: false
+    name: cp
+    path: /bin/cp
+  - action: allow
+    allow_update: false
+    name: df
+    path: /bin/df
+  - action: allow
+    allow_update: false
+    name: dirname
+    path: /usr/bin/dirname
+  - action: allow
+    allow_update: false
+    name: dpkg
+    path: /usr/bin/dpkg
+  - action: allow
+    allow_update: false
+    name: dpkg-query
+    path: /usr/bin/dpkg-query
+  - action: allow
+    allow_update: false
+    name: du
+    path: /usr/bin/du
+  - action: allow
+    allow_update: false
+    name: env
+    path: /usr/bin/env
+  - action: allow
+    allow_update: false
+    name: getconf
+    path: /usr/bin/getconf
+  - action: allow
+    allow_update: false
+    name: gzip
+    path: /bin/gzip
+  - action: allow
+    allow_update: false
+    name: hadoop
+    path: /usr/bin/env
+  - action: allow
+    allow_update: false
+    name: hdfs
+    path: /usr/bin/env
+  - action: allow
+    allow_update: false
+    name: head
+    path: /usr/bin/head
+  - action: allow
+    allow_update: false
+    name: id
+    path: /usr/bin/id
+  - action: allow
+    allow_update: false
+    name: java
+    path: /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+  - action: allow
+    allow_update: false
+    name: jks-keystore
+    path: /bin/dash
+  - action: allow
+    allow_update: false
+    name: ld-2.28.so
+    path: /lib/x86_64-linux-gnu/ld-2.28.so
+  - action: allow
+    allow_update: false
+    name: ld-linux-x86-64
+    path: /lib/x86_64-linux-gnu/ld-2.28.so
+  - action: allow
+    allow_update: false
+    name: ld-linux-x86-64.so.2
+    path: /lib/x86_64-linux-gnu/ld-2.28.so
+  - action: allow
+    allow_update: false
+    name: ldd
+    path: /bin/bash
+  - action: allow
+    allow_update: false
+    name: ls
+    path: /bin/ls
+  - action: allow
+    allow_update: false
+    name: mkdir
+    path: /bin/mkdir
+  - action: allow
+    allow_update: false
+    name: mountpoint
+    path: /bin/mountpoint
+  - action: allow
+    allow_update: false
+    name: mv
+    path: /bin/mv
+  - action: allow
+    allow_update: false
+    name: nice
+    path: /usr/bin/nice
+  - action: allow
+    allow_update: false
+    name: nohup
+    path: /usr/bin/nohup
+  - action: allow
+    allow_update: false
+    name: pause
+    path: /pause
+  - action: allow
+    allow_update: false
+    name: ps
+    path: /bin/ps
+  - action: allow
+    allow_update: false
+    name: psql
+    path: /usr/bin/perl
+  - action: allow
+    allow_update: false
+    name: psql
+    path: /usr/lib/postgresql/11/bin/psql
+  - action: allow
+    allow_update: false
+    name: python
+    path: /usr/local/bin/python3.9
+  - action: allow
+    allow_update: false
+    name: python3
+    path: /usr/local/bin/python3.9
+  - action: allow
+    allow_update: false
+    name: readlink
+    path: /bin/readlink
+  - action: allow
+    allow_update: false
+    name: renice
+    path: /usr/bin/renice
+  - action: allow
+    allow_update: false
+    name: rm
+    path: /bin/rm
+  - action: allow
+    allow_update: false
+    name: sed
+    path: /bin/sed
+  - action: allow
+    allow_update: false
+    name: setsid
+    path: /usr/bin/setsid
+  - action: allow
+    allow_update: false
+    name: sh
+    path: /bin/dash
+  - action: allow
+    allow_update: false
+    name: slaves.sh
+    path: /usr/bin/env
+  - action: allow
+    allow_update: false
+    name: sleep
+    path: /bin/sleep
+  - action: allow
+    allow_update: false
+    name: spark-class
+    path: /usr/bin/env
+  - action: allow
+    allow_update: false
+    name: spark-submit
+    path: /usr/bin/env
+  - action: allow
+    allow_update: false
+    name: sqoop
+    path: /bin/bash
+  - action: allow
+    allow_update: false
+    name: ssh-keygen
+    path: /usr/bin/ssh-keygen
+  - action: allow
+    allow_update: false
+    name: sysctl
+    path: /sbin/sysctl
+  - action: allow
+    allow_update: false
+    name: tail
+    path: /usr/bin/tail
+  - action: allow
+    allow_update: false
+    name: tar
+    path: /bin/tar
+  - action: allow
+    allow_update: false
+    name: touch
+    path: /bin/touch
+  - action: allow
+    allow_update: false
+    name: tr
+    path: /usr/bin/tr
+  - action: allow
+    allow_update: false
+    name: uname
+    path: /bin/uname
+  - action: allow
+    allow_update: false
+    name: wget
+    path: /usr/bin/wget
+  - action: allow
+    allow_update: false
+    name: yarn
+    path: /usr/bin/env
+  process_profile:
+    baseline: zero-drift
+  target:
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: regex
+        value: etl-cronjob-.*\.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: etl-cronjob.{{ .Release.Namespace }}
+      original_name: ""
+  waf:
+    settings: []
+    status: true

--- a/helm/neuvector/templates/fence-nvsecurityrule.yaml
+++ b/helm/neuvector/templates/fence-nvsecurityrule.yaml
@@ -1,0 +1,294 @@
+{{- if .Values.policies.include }}
+apiVersion: neuvector.com/v1
+kind: NvSecurityRule
+metadata:
+  name: nv.fence-deployment.{{ .Release.Namespace }}
+spec:
+  dlp:
+    settings: []
+    status: true
+  egress:
+  - action: allow
+    applications:
+    - any
+    name: nodes-egress-12
+    ports: tcp/8126
+    priority: 0
+    selector:
+      comment: ""
+      criteria: []
+      name: nodes
+      original_name: ""
+  - action: allow
+    applications:
+    - DNS
+    name: nv.kube-dns.kube-system-egress-13
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: kube-dns.kube-system
+      - key: domain
+        op: =
+        value: kube-system
+      name: nv.kube-dns.kube-system
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: external-egress-14
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria: []
+      name: external
+      original_name: ""
+  file: []
+  ingress:
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.fence-deployment.{{ .Release.Namespace }}-ingress-31
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      name: Workload:ingress
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: nv.fence-deployment.{{ .Release.Namespace }}-ingress-32
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria: []
+      name: external
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.fence-deployment.{{ .Release.Namespace }}-ingress-33
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: revproxy-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.revproxy-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: nv.fence-deployment.{{ .Release.Namespace }}-ingress-34
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: peregrine-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.peregrine-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: nv.fence-deployment.{{ .Release.Namespace }}-ingress-35
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: hatchery-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.hatchery-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: nv.fence-deployment.{{ .Release.Namespace }}-ingress-36
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: sheepdog-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.sheepdog-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: nv.fence-deployment.{{ .Release.Namespace }}-ingress-37
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: cert-manager.cert-manager
+      - key: domain
+        op: =
+        value: cert-manager
+      name: nv.cert-manager.cert-manager
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.fence-deployment.{{ .Release.Namespace }}-ingress-38
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: manifestservice-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.manifestservice-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  process:
+  - action: allow
+    allow_update: false
+    name: basename
+    path: /usr/bin/basename
+  - action: allow
+    allow_update: false
+    name: bash
+    path: /bin/bash
+  - action: allow
+    allow_update: false
+    name: cat
+    path: /bin/cat
+  - action: allow
+    allow_update: false
+    name: chmod
+    path: /bin/chmod
+  - action: allow
+    allow_update: false
+    name: chown
+    path: /bin/chown
+  - action: allow
+    allow_update: false
+    name: ddtrace-run
+    path: /usr/local/bin/python3.9
+  - action: allow
+    allow_update: false
+    name: fence-create
+    path: /usr/local/bin/python3.9
+  - action: allow
+    allow_update: false
+    name: find
+    path: /usr/bin/find
+  - action: allow
+    allow_update: false
+    name: ldconfig
+    path: /sbin/ldconfig
+  - action: allow
+    allow_update: false
+    name: ls
+    path: /bin/ls
+  - action: allow
+    allow_update: false
+    name: mkdir
+    path: /bin/mkdir
+  - action: allow
+    allow_update: false
+    name: mv
+    path: /bin/mv
+  - action: allow
+    allow_update: false
+    name: nginx
+    path: /usr/sbin/nginx
+  - action: allow
+    allow_update: false
+    name: pause
+    path: /pause
+  - action: allow
+    allow_update: false
+    name: pip
+    path: /usr/local/bin/python3.9
+  - action: allow
+    allow_update: false
+    name: python
+    path: /usr/local/bin/python3.9
+  - action: allow
+    allow_update: false
+    name: readlink
+    path: /bin/readlink
+  - action: allow
+    allow_update: false
+    name: rm
+    path: /bin/rm
+  - action: allow
+    allow_update: false
+    name: run-parts
+    path: /bin/run-parts
+  - action: allow
+    allow_update: false
+    name: sed
+    path: /bin/sed
+  - action: allow
+    allow_update: false
+    name: sh
+    path: /bin/dash
+  - action: allow
+    allow_update: false
+    name: sort
+    path: /usr/bin/sort
+  - action: allow
+    allow_update: false
+    name: uname
+    path: /bin/uname
+  - action: allow
+    allow_update: false
+    name: uwsgi
+    path: /usr/local/bin/uwsgi
+  - action: allow
+    allow_update: false
+    name: wc
+    path: /usr/bin/wc
+  process_profile:
+    baseline: zero-drift
+  target:
+    policymode: {{ .Values.policies.policyMode }}
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: fence-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.fence-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  waf:
+    settings: []
+    status: true
+{{- end }}

--- a/helm/neuvector/templates/guppy-nvsecurityrule.yaml
+++ b/helm/neuvector/templates/guppy-nvsecurityrule.yaml
@@ -1,0 +1,129 @@
+{{- if .Values.policies.include }}
+apiVersion: neuvector.com/v1
+kind: NvSecurityRule
+metadata:
+  name: nv.guppy-deployment.{{ .Release.Namespace }}
+spec:
+  dlp:
+    settings: []
+    status: true
+  egress:
+  - action: allow
+    applications:
+    - DNS
+    name: nv.kube-dns.kube-system-egress-15
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: kube-dns.kube-system
+      - key: domain
+        op: =
+        value: kube-system
+      name: nv.kube-dns.kube-system
+      original_name: ""
+  file: []
+  ingress:
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.guppy-deployment.{{ .Release.Namespace }}-ingress-42
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      name: Workload:ingress
+      original_name: ""
+  - action: allow
+    applications:
+    - any
+    name: nv.guppy-deployment.{{ .Release.Namespace }}-ingress-43
+    ports: tcp/8000
+    priority: 0
+    selector:
+      comment: ""
+      name: Workload:ingress
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: nv.guppy-deployment.{{ .Release.Namespace }}-ingress-44
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria: []
+      name: external
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.guppy-deployment.{{ .Release.Namespace }}-ingress-45
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: revproxy-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.revproxy-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  process:
+  - action: allow
+    allow_update: false
+    name: bash
+    path: /usr/bin/bash
+  - action: allow
+    allow_update: false
+    name: cat
+    path: /usr/bin/cat
+  - action: allow
+    allow_update: false
+    name: dash
+    path: /usr/bin/dash
+  - action: allow
+    allow_update: false
+    name: ls
+    path: /usr/bin/ls
+  - action: allow
+    allow_update: false
+    name: node
+    path: /usr/bin/node
+  - action: allow
+    allow_update: false
+    name: pause
+    path: /pause
+  - action: allow
+    allow_update: false
+    name: runc
+    path: /usr/bin/runc
+  - action: allow
+    allow_update: false
+    name: sh
+    path: /usr/bin/dash
+  process_profile:
+    baseline: zero-drift
+  target:
+    policymode: {{ .Values.policies.policyMode }}
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: guppy-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.guppy-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  waf:
+    settings: []
+    status: true
+{{- end }}

--- a/helm/neuvector/templates/hatchery-nvsecurityrule.yaml
+++ b/helm/neuvector/templates/hatchery-nvsecurityrule.yaml
@@ -1,0 +1,140 @@
+{{- if .Values.policies.include }}
+apiVersion: neuvector.com/v1
+kind: NvSecurityRule
+metadata:
+  name: nv.hatchery-deployment.{{ .Release.Namespace }}
+spec:
+  dlp:
+    settings: []
+    status: true
+  egress:
+  - action: allow
+    applications:
+    - DNS
+    name: nv.kube-dns.kube-system-egress-16
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: kube-dns.kube-system
+      - key: domain
+        op: =
+        value: kube-system
+      name: nv.kube-dns.kube-system
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: nv.{{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}-egress-17
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: {{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}
+      - key: domain
+        op: =
+        value: {{ .Values.ingress.class }}
+      name: nv.{{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: external-egress-18
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria: []
+      name: external
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: nv.revproxy-deployment.{{ .Release.Namespace }}-egress-19
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: revproxy-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.revproxy-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  file: []
+  ingress:
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.hatchery-deployment.{{ .Release.Namespace }}-ingress-46
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      name: Workload:ingress
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: nv.hatchery-deployment.{{ .Release.Namespace }}-ingress-47
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria: []
+      name: external
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.hatchery-deployment.{{ .Release.Namespace }}-ingress-48
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: revproxy-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.revproxy-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  process:
+  - action: allow
+    allow_update: false
+    name: hatchery
+    path: /hatchery
+  - action: allow
+    allow_update: false
+    name: pause
+    path: /pause
+  process_profile:
+    baseline: zero-drift
+  target:
+    policymode: {{ .Values.policies.policyMode }}
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: hatchery-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.hatchery-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  waf:
+    settings: []
+    status: true
+{{- end }}

--- a/helm/neuvector/templates/indexd-nvsecurityrule.yaml
+++ b/helm/neuvector/templates/indexd-nvsecurityrule.yaml
@@ -1,0 +1,152 @@
+{{- if .Values.policies.include }}
+apiVersion: neuvector.com/v1
+kind: NvSecurityRule
+metadata:
+  name: nv.indexd-deployment.{{ .Release.Namespace }}
+spec:
+  dlp:
+    settings: []
+    status: true
+  egress:
+  - action: allow
+    applications:
+    - DNS
+    name: nv.kube-dns.kube-system-egress-20
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: kube-dns.kube-system
+      - key: domain
+        op: =
+        value: kube-system
+      name: nv.kube-dns.kube-system
+      original_name: ""
+  file: []
+  ingress:
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.indexd-deployment.{{ .Release.Namespace }}-ingress-49
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      name: Workload:ingress
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: nv.indexd-deployment.{{ .Release.Namespace }}-ingress-50
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria: []
+      name: external
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.indexd-deployment.{{ .Release.Namespace }}-ingress-51
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: revproxy-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.revproxy-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.indexd-deployment.{{ .Release.Namespace }}-ingress-52
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: sheepdog-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.sheepdog-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  process:
+  - action: allow
+    allow_update: false
+    name: bash
+    path: /bin/bash
+  - action: allow
+    allow_update: false
+    name: chmod
+    path: /bin/chmod
+  - action: allow
+    allow_update: false
+    name: chown
+    path: /bin/chown
+  - action: allow
+    allow_update: false
+    name: dockerrun.sh
+    path: /bin/dash
+  - action: allow
+    allow_update: false
+    name: mkdir
+    path: /bin/mkdir
+  - action: allow
+    allow_update: false
+    name: mv
+    path: /bin/mv
+  - action: allow
+    allow_update: false
+    name: nginx
+    path: /usr/sbin/nginx
+  - action: allow
+    allow_update: false
+    name: pause
+    path: /pause
+  - action: allow
+    allow_update: false
+    name: rm
+    path: /bin/rm
+  - action: allow
+    allow_update: false
+    name: run-parts
+    path: /bin/run-parts
+  - action: allow
+    allow_update: false
+    name: sh
+    path: /bin/dash
+  - action: allow
+    allow_update: false
+    name: uwsgi
+    path: /usr/local/bin/uwsgi
+  process_profile:
+    baseline: zero-drift
+  target:
+    policymode: {{ .Values.policies.policyMode }}
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: indexd-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.indexd-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  waf:
+    settings: []
+    status: true
+{{- end }}

--- a/helm/neuvector/templates/ingress-nvclustersecurityrule.yaml
+++ b/helm/neuvector/templates/ingress-nvclustersecurityrule.yaml
@@ -1,0 +1,130 @@
+{{- if .Values.policies.include }}
+apiVersion: neuvector.com/v1
+kind: NvClusterSecurityRule
+metadata:
+  name: {{ .Release.Namespace }}
+  namespace: ""
+spec:
+  dlp:
+    settings: []
+    status: true
+  egress: []
+  file: []
+  ingress:
+  - action: allow
+    applications:
+    - any
+    name: {{ .Release.Namespace }}-ingress-0
+    ports: tcp/8089
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: {{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}
+      - key: domain
+        op: =
+        value: {{ .Values.ingress.class }}
+      name: nv.{{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - any
+    name: {{ .Release.Namespace }}-ingress-1
+    ports: tcp/8089
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: {{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}
+      - key: domain
+        op: =
+        value: {{ .Values.ingress.class }}
+      name: nv.{{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - any
+    name: {{ .Release.Namespace }}-ingress-2
+    ports: tcp/8089
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: {{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}
+      - key: domain
+        op: =
+        value: {{ .Values.ingress.class }}
+      name: nv.{{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - any
+    name: {{ .Release.Namespace }}-ingress-3
+    ports: tcp/8089
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: {{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}
+      - key: domain
+        op: =
+        value: {{ .Values.ingress.class }}
+      name: nv.{{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - any
+    name: {{ .Release.Namespace }}-ingress-4
+    ports: tcp/8089
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: {{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}
+      - key: domain
+        op: =
+        value: {{ .Values.ingress.class }}
+      name: nv.{{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}
+      original_name: ""
+  - action: deny
+    applications:
+    - any
+    name: {{ .Release.Namespace }}-ingress-5
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: {{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}
+      - key: domain
+        op: =
+        value: {{ .Values.ingress.class }}
+      name: nv.{{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}
+      original_name: ""
+  process: []
+  target:
+    policymode: N/A
+    selector:
+      comment: gen3 development group
+      criteria:
+      - key: namespace
+        op: =
+        value: {{ .Release.Namespace }}
+      name: {{ .Release.Namespace }}
+      original_name: ""
+  waf:
+    settings: []
+    status: true
+{{- end }}

--- a/helm/neuvector/templates/manifestservice-nvsecurityrule.yaml
+++ b/helm/neuvector/templates/manifestservice-nvsecurityrule.yaml
@@ -1,0 +1,166 @@
+{{- if .Values.policies.include }}
+apiVersion: neuvector.com/v1
+kind: NvSecurityRule
+metadata:
+  name: nv.manifestservice-deployment.{{ .Release.Namespace }}
+spec:
+  dlp:
+    settings: []
+    status: true
+  egress:
+  - action: allow
+    applications:
+    - DNS
+    name: nv.kube-dns.kube-system-egress-21
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: kube-dns.kube-system
+      - key: domain
+        op: =
+        value: kube-system
+      name: nv.kube-dns.kube-system
+      original_name: ""
+  file: []
+  ingress:
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.manifestservice-deployment.{{ .Release.Namespace }}-ingress-53
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      name: Workload:ingress
+      original_name: ""
+  - action: allow
+    applications:
+    - any
+    name: nv.manifestservice-deployment.{{ .Release.Namespace }}-ingress-54
+    ports: tcp/80
+    priority: 0
+    selector:
+      comment: ""
+      name: Workload:ingress
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.manifestservice-deployment.{{ .Release.Namespace }}-ingress-55
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: revproxy-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.revproxy-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  process:
+  - action: allow
+    allow_update: false
+    name: basename
+    path: /usr/bin/basename
+  - action: allow
+    allow_update: false
+    name: cat
+    path: /bin/cat
+  - action: allow
+    allow_update: false
+    name: chmod
+    path: /bin/chmod
+  - action: allow
+    allow_update: false
+    name: dockerrun.sh
+    path: /bin/dash
+  - action: allow
+    allow_update: false
+    name: find
+    path: /usr/bin/find
+  - action: allow
+    allow_update: false
+    name: grep
+    path: /bin/grep
+  - action: allow
+    allow_update: false
+    name: ldconfig
+    path: /sbin/ldconfig
+  - action: allow
+    allow_update: false
+    name: mkdir
+    path: /bin/mkdir
+  - action: allow
+    allow_update: false
+    name: mktemp
+    path: /bin/mktemp
+  - action: allow
+    allow_update: false
+    name: mv
+    path: /bin/mv
+  - action: allow
+    allow_update: false
+    name: nginx
+    path: /usr/sbin/nginx
+  - action: allow
+    allow_update: false
+    name: pause
+    path: /pause
+  - action: allow
+    allow_update: false
+    name: readlink
+    path: /bin/readlink
+  - action: allow
+    allow_update: false
+    name: rm
+    path: /bin/rm
+  - action: allow
+    allow_update: false
+    name: run-parts
+    path: /bin/run-parts
+  - action: allow
+    allow_update: false
+    name: sed
+    path: /bin/sed
+  - action: allow
+    allow_update: false
+    name: sh
+    path: /bin/dash
+  - action: allow
+    allow_update: false
+    name: sort
+    path: /usr/bin/sort
+  - action: allow
+    allow_update: false
+    name: uwsgi
+    path: /usr/local/bin/uwsgi
+  - action: allow
+    allow_update: false
+    name: wc
+    path: /usr/bin/wc
+  process_profile:
+    baseline: zero-drift
+  target:
+    policymode: {{ .Values.policies.policyMode }}
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: manifestservice-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.manifestservice-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  waf:
+    settings: []
+    status: true
+{{- end }}

--- a/helm/neuvector/templates/metadata-nvsecurityrule.yaml
+++ b/helm/neuvector/templates/metadata-nvsecurityrule.yaml
@@ -1,0 +1,87 @@
+{{- if .Values.policies.include }}
+apiVersion: neuvector.com/v1
+kind: NvSecurityRule
+metadata:
+  name: nv.metadata-deployment.{{ .Release.Namespace }}
+spec:
+  dlp:
+    settings: []
+    status: true
+  egress:
+  - action: allow
+    applications:
+    - DNS
+    name: nv.kube-dns.kube-system-egress-22
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: kube-dns.kube-system
+      - key: domain
+        op: =
+        value: kube-system
+      name: nv.kube-dns.kube-system
+      original_name: ""
+  file: []
+  ingress:
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.metadata-deployment.{{ .Release.Namespace }}-ingress-56
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      name: Workload:ingress
+      original_name: ""
+  process:
+  - action: allow
+    allow_update: false
+    name: alembic
+    path: /usr/local/bin/python3.9
+  - action: allow
+    allow_update: false
+    name: grep
+    path: /bin/grep
+  - action: allow
+    allow_update: false
+    name: gunicorn
+    path: /usr/local/bin/python3.9
+  - action: allow
+    allow_update: false
+    name: pause
+    path: /pause
+  - action: allow
+    allow_update: false
+    name: runc
+    path: /usr/bin/runc
+  - action: allow
+    allow_update: false
+    name: sed
+    path: /bin/sed
+  - action: allow
+    allow_update: false
+    name: sh
+    path: /bin/dash
+  process_profile:
+    baseline: zero-drift
+  target:
+    policymode: {{ .Values.policies.policyMode }}
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: metadata-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.metadata-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  waf:
+    settings: []
+    status: true
+{{- end }}

--- a/helm/neuvector/templates/peregrine-nvsecurityrule.yaml
+++ b/helm/neuvector/templates/peregrine-nvsecurityrule.yaml
@@ -1,0 +1,258 @@
+{{- if .Values.policies.include }}
+apiVersion: neuvector.com/v1
+kind: NvSecurityRule
+metadata:
+  name: nv.peregrine-deployment.{{ .Release.Namespace }}
+spec:
+  dlp:
+    settings: []
+    status: true
+  egress:
+  - action: allow
+    applications:
+    - DNS
+    name: nv.kube-dns.kube-system-egress-23
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: kube-dns.kube-system
+      - key: domain
+        op: =
+        value: kube-system
+      name: nv.kube-dns.kube-system
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: nv.revproxy-deployment.{{ .Release.Namespace }}-egress-24
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: revproxy-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.revproxy-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    - SSL
+    name: external-egress-25
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria: []
+      name: external
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    - SSL
+    name: nv.{{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}-egress-26
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: {{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}
+      - key: domain
+        op: =
+        value: {{ .Values.ingress.class }}
+      name: nv.{{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}
+      original_name: ""
+  file: []
+  ingress:
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.peregrine-deployment.{{ .Release.Namespace }}-ingress-57
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      name: Workload:ingress
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.peregrine-deployment.{{ .Release.Namespace }}-ingress-58
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: pidgin-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.pidgin-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: nv.peregrine-deployment.{{ .Release.Namespace }}-ingress-59
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria: []
+      name: external
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.peregrine-deployment.{{ .Release.Namespace }}-ingress-60
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: revproxy-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.revproxy-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - any
+    name: nv.peregrine-deployment.{{ .Release.Namespace }}-ingress-61
+    ports: tcp/80
+    priority: 0
+    selector:
+      comment: ""
+      name: Workload:ingress
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.peregrine-deployment.{{ .Release.Namespace }}-ingress-62
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: portal-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.portal-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  process:
+  - action: allow
+    allow_update: false
+    name: basename
+    path: /usr/bin/basename
+  - action: allow
+    allow_update: false
+    name: cat
+    path: /bin/cat
+  - action: allow
+    allow_update: false
+    name: chmod
+    path: /bin/chmod
+  - action: allow
+    allow_update: false
+    name: dash
+    path: /bin/dash
+  - action: allow
+    allow_update: false
+    name: dockerrun.sh
+    path: /bin/dash
+  - action: allow
+    allow_update: false
+    name: find
+    path: /usr/bin/find
+  - action: allow
+    allow_update: false
+    name: grep
+    path: /bin/grep
+  - action: allow
+    allow_update: false
+    name: mkdir
+    path: /bin/mkdir
+  - action: allow
+    allow_update: false
+    name: mktemp
+    path: /bin/mktemp
+  - action: allow
+    allow_update: false
+    name: mv
+    path: /bin/mv
+  - action: allow
+    allow_update: false
+    name: nginx
+    path: /usr/sbin/nginx
+  - action: allow
+    allow_update: false
+    name: pause
+    path: /pause
+  - action: allow
+    allow_update: false
+    name: readlink
+    path: /bin/readlink
+  - action: allow
+    allow_update: false
+    name: rm
+    path: /bin/rm
+  - action: allow
+    allow_update: false
+    name: run-parts
+    path: /bin/run-parts
+  - action: allow
+    allow_update: false
+    name: sed
+    path: /bin/sed
+  - action: allow
+    allow_update: false
+    name: sh
+    path: /bin/dash
+  - action: allow
+    allow_update: false
+    name: sort
+    path: /usr/bin/sort
+  - action: allow
+    allow_update: false
+    name: uwsgi
+    path: /usr/local/bin/uwsgi
+  - action: allow
+    allow_update: false
+    name: wc
+    path: /usr/bin/wc
+  process_profile:
+    baseline: zero-drift
+  target:
+    policymode: {{ .Values.policies.policyMode }}
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: peregrine-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.peregrine-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  waf:
+    settings: []
+    status: true
+{{- end }}

--- a/helm/neuvector/templates/pidgin-nvsecurityrule.yaml
+++ b/helm/neuvector/templates/pidgin-nvsecurityrule.yaml
@@ -1,0 +1,135 @@
+{{- if .Values.policies.include }}
+apiVersion: neuvector.com/v1
+kind: NvSecurityRule
+metadata:
+  name: nv.pidgin-deployment.{{ .Release.Namespace }}
+spec:
+  dlp:
+    settings: []
+    status: true
+  egress:
+  - action: allow
+    applications:
+    - DNS
+    name: nv.kube-dns.kube-system-egress-27
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: kube-dns.kube-system
+      - key: domain
+        op: =
+        value: kube-system
+      name: nv.kube-dns.kube-system
+      original_name: ""
+  file: []
+  ingress:
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.pidgin-deployment.{{ .Release.Namespace }}-ingress-63
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      name: Workload:ingress
+      original_name: ""
+  process:
+  - action: allow
+    allow_update: false
+    name: basename
+    path: /usr/bin/basename
+  - action: allow
+    allow_update: false
+    name: chmod
+    path: /bin/chmod
+  - action: allow
+    allow_update: false
+    name: dash
+    path: /bin/dash
+  - action: allow
+    allow_update: false
+    name: dockerrun.sh
+    path: /bin/dash
+  - action: allow
+    allow_update: false
+    name: find
+    path: /usr/bin/find
+  - action: allow
+    allow_update: false
+    name: grep
+    path: /bin/grep
+  - action: allow
+    allow_update: false
+    name: mkdir
+    path: /bin/mkdir
+  - action: allow
+    allow_update: false
+    name: mktemp
+    path: /bin/mktemp
+  - action: allow
+    allow_update: false
+    name: mv
+    path: /bin/mv
+  - action: allow
+    allow_update: false
+    name: nginx
+    path: /usr/sbin/nginx
+  - action: allow
+    allow_update: false
+    name: pause
+    path: /pause
+  - action: allow
+    allow_update: false
+    name: readlink
+    path: /bin/readlink
+  - action: allow
+    allow_update: false
+    name: rm
+    path: /bin/rm
+  - action: allow
+    allow_update: false
+    name: run-parts
+    path: /bin/run-parts
+  - action: allow
+    allow_update: false
+    name: sed
+    path: /bin/sed
+  - action: allow
+    allow_update: false
+    name: sh
+    path: /bin/dash
+  - action: allow
+    allow_update: false
+    name: sort
+    path: /usr/bin/sort
+  - action: allow
+    allow_update: false
+    name: uwsgi
+    path: /usr/local/bin/uwsgi
+  - action: allow
+    allow_update: false
+    name: wc
+    path: /usr/bin/wc
+  process_profile:
+    baseline: zero-drift
+  target:
+    policymode: {{ .Values.policies.policyMode }}
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: pidgin-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.pidgin-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  waf:
+    settings: []
+    status: true
+{{- end }}

--- a/helm/neuvector/templates/portal-nvsecurityrule.yaml
+++ b/helm/neuvector/templates/portal-nvsecurityrule.yaml
@@ -1,0 +1,182 @@
+{{- if .Values.policies.include }}
+apiVersion: neuvector.com/v1
+kind: NvSecurityRule
+metadata:
+  name: nv.portal-deployment.{{ .Release.Namespace }}
+spec:
+  dlp:
+    settings: []
+    status: true
+  egress:
+  - action: allow
+    applications:
+    - any
+    name: nv.revproxy-deployment.{{ .Release.Namespace }}-egress-28
+    ports: tcp/80
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: revproxy-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.revproxy-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - any
+    name: nv.revproxy-deployment.{{ .Release.Namespace }}-egress-29
+    ports: tcp/80
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: revproxy-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.revproxy-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - any
+    name: nv.revproxy-deployment.{{ .Release.Namespace }}-egress-30
+    ports: tcp/80
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: revproxy-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.revproxy-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.sheepdog-deployment.{{ .Release.Namespace }}-egress-31
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: sheepdog-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.sheepdog-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  file: []
+  ingress:
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.portal-deployment.{{ .Release.Namespace }}-ingress-64
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      name: Workload:ingress
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.portal-deployment.{{ .Release.Namespace }}-ingress-65
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: revproxy-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.revproxy-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: nv.portal-deployment.{{ .Release.Namespace }}-ingress-66
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria: []
+      name: external
+      original_name: ""
+  process:
+  - action: allow
+    allow_update: false
+    name: bash
+    path: /usr/bin/bash
+  - action: allow
+    allow_update: false
+    name: nginx
+    path: /usr/sbin/nginx
+  - action: allow
+    allow_update: false
+    name: node
+    path: /usr/bin/node
+  - action: allow
+    allow_update: false
+    name: npm
+    path: /usr/bin/env
+  - action: allow
+    allow_update: false
+    name: npm
+    path: /usr/bin/node
+  - action: allow
+    allow_update: false
+    name: npx
+    path: /usr/bin/env
+  - action: allow
+    allow_update: false
+    name: pause
+    path: /pause
+  - action: allow
+    allow_update: false
+    name: relay-compiler
+    path: /usr/bin/env
+  - action: allow
+    allow_update: false
+    name: sh
+    path: /usr/bin/dash
+  - action: allow
+    allow_update: false
+    name: webpack
+    path: /usr/bin/env
+  - action: allow
+    allow_update: false
+    name: webpack
+    path: /usr/bin/node
+  process_profile:
+    baseline: zero-drift
+  target:
+    policymode: {{ .Values.policies.policyMode }}
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: portal-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.portal-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  waf:
+    settings: []
+    status: true
+{{- end }}

--- a/helm/neuvector/templates/postgresql-nvsecurityrule.yaml
+++ b/helm/neuvector/templates/postgresql-nvsecurityrule.yaml
@@ -1,0 +1,138 @@
+{{- if .Values.policies.include }}
+apiVersion: neuvector.com/v1
+kind: NvSecurityRule
+metadata:
+  name: nv.{{ .Values.DB_HOST }}.{{ .Release.Namespace }}
+spec:
+  dlp:
+    settings: []
+    status: true
+  egress: []
+  file: []
+  ingress:
+  - action: allow
+    applications:
+    - PostgreSQL
+    name: nv.{{ .Values.DB_HOST }}.{{ .Release.Namespace }}-ingress-25
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: peregrine-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.peregrine-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - PostgreSQL
+    name: nv.{{ .Values.DB_HOST }}.{{ .Release.Namespace }}-ingress-26
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: sheepdog-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.sheepdog-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - PostgreSQL
+    name: nv.{{ .Values.DB_HOST }}.{{ .Release.Namespace }}-ingress-27
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: indexd-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.indexd-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - PostgreSQL
+    name: nv.{{ .Values.DB_HOST }}.{{ .Release.Namespace }}-ingress-28
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: metadata-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.metadata-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - PostgreSQL
+    name: nv.{{ .Values.DB_HOST }}.{{ .Release.Namespace }}-ingress-29
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: presigned-url-fence-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.presigned-url-fence-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - PostgreSQL
+    name: nv.{{ .Values.DB_HOST }}.{{ .Release.Namespace }}-ingress-30
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: fence-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.fence-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  process:
+  - action: allow
+    allow_update: false
+    name: sh
+    path: '*'
+  process_profile:
+    baseline: zero-drift
+  target:
+    policymode: {{ .Values.policies.policyMode }}
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: {{ .Values.DB_HOST }}.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.{{ .Values.DB_HOST }}.{{ .Release.Namespace }}
+      original_name: ""
+  waf:
+    settings: []
+    status: true
+{{- end }}

--- a/helm/neuvector/templates/presigned-url-fence-nvsecurityrule.yaml
+++ b/helm/neuvector/templates/presigned-url-fence-nvsecurityrule.yaml
@@ -1,0 +1,173 @@
+{{- if .Values.policies.include }}
+apiVersion: neuvector.com/v1
+kind: NvSecurityRule
+metadata:
+  name: nv.presigned-url-fence-deployment.{{ .Release.Namespace }}
+spec:
+  dlp:
+    settings: []
+    status: true
+  egress:
+  - action: allow
+    applications:
+    - any
+    name: nodes-egress-32
+    ports: tcp/8126
+    priority: 0
+    selector:
+      comment: ""
+      criteria: []
+      name: nodes
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: external-egress-33
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria: []
+      name: external
+      original_name: ""
+  - action: allow
+    applications:
+    - DNS
+    name: nv.kube-dns.kube-system-egress-34
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: kube-dns.kube-system
+      - key: domain
+        op: =
+        value: kube-system
+      name: nv.kube-dns.kube-system
+      original_name: ""
+  file: []
+  ingress:
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.presigned-url-fence-deployment.{{ .Release.Namespace }}-ingress-67
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      name: Workload:ingress
+      original_name: ""
+  process:
+  - action: allow
+    allow_update: false
+    name: basename
+    path: /usr/bin/basename
+  - action: allow
+    allow_update: false
+    name: bash
+    path: /bin/bash
+  - action: allow
+    allow_update: false
+    name: cat
+    path: /bin/cat
+  - action: allow
+    allow_update: false
+    name: chmod
+    path: /bin/chmod
+  - action: allow
+    allow_update: false
+    name: chown
+    path: /bin/chown
+  - action: allow
+    allow_update: false
+    name: ddtrace-run
+    path: /usr/local/bin/python3.9
+  - action: allow
+    allow_update: false
+    name: find
+    path: /usr/bin/find
+  - action: allow
+    allow_update: false
+    name: ldconfig
+    path: /sbin/ldconfig
+  - action: allow
+    allow_update: false
+    name: mkdir
+    path: /bin/mkdir
+  - action: allow
+    allow_update: false
+    name: mktemp
+    path: /bin/mktemp
+  - action: allow
+    allow_update: false
+    name: mv
+    path: /bin/mv
+  - action: allow
+    allow_update: false
+    name: nginx
+    path: /usr/sbin/nginx
+  - action: allow
+    allow_update: false
+    name: pause
+    path: /pause
+  - action: allow
+    allow_update: false
+    name: pip
+    path: /usr/local/bin/python3.9
+  - action: allow
+    allow_update: false
+    name: readlink
+    path: /bin/readlink
+  - action: allow
+    allow_update: false
+    name: rm
+    path: /bin/rm
+  - action: allow
+    allow_update: false
+    name: run-parts
+    path: /bin/run-parts
+  - action: allow
+    allow_update: false
+    name: sed
+    path: /bin/sed
+  - action: allow
+    allow_update: false
+    name: sh
+    path: /bin/dash
+  - action: allow
+    allow_update: false
+    name: sort
+    path: /usr/bin/sort
+  - action: allow
+    allow_update: false
+    name: uname
+    path: /bin/uname
+  - action: allow
+    allow_update: false
+    name: uwsgi
+    path: /usr/local/bin/uwsgi
+  - action: allow
+    allow_update: false
+    name: wc
+    path: /usr/bin/wc
+  process_profile:
+    baseline: zero-drift
+  target:
+    policymode: {{ .Values.policies.policyMode }}
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: presigned-url-fence-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.presigned-url-fence-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  waf:
+    settings: []
+    status: true
+{{- end }}

--- a/helm/neuvector/templates/revproxy-nvsecurityrule.yaml
+++ b/helm/neuvector/templates/revproxy-nvsecurityrule.yaml
@@ -1,0 +1,175 @@
+{{- if .Values.policies.include }}
+apiVersion: neuvector.com/v1
+kind: NvSecurityRule
+metadata:
+  name: nv.revproxy-deployment.{{ .Release.Namespace }}
+spec:
+  dlp:
+    settings: []
+    status: true
+  egress:
+  - action: allow
+    applications:
+    - DNS
+    name: nv.kube-dns.kube-system-egress-35
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: kube-dns.kube-system
+      - key: domain
+        op: =
+        value: kube-system
+      name: nv.kube-dns.kube-system
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.sheepdog-deployment.{{ .Release.Namespace }}-egress-36
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: sheepdog-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.sheepdog-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  file: []
+  ingress:
+  - action: allow
+    applications:
+    - any
+    name: nv.revproxy-deployment.{{ .Release.Namespace }}-ingress-68
+    ports: tcp/80,tcp/443
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: {{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}
+      - key: domain
+        op: =
+        value: {{ .Values.ingress.class }}
+      name: nv.{{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.revproxy-deployment.{{ .Release.Namespace }}-ingress-69
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      name: Workload:ingress
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.revproxy-deployment.{{ .Release.Namespace }}-ingress-70
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: {{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}
+      - key: domain
+        op: =
+        value: {{ .Values.ingress.class }}
+      name: nv.{{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: nv.revproxy-deployment.{{ .Release.Namespace }}-ingress-71
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria: []
+      name: external
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: nv.revproxy-deployment.{{ .Release.Namespace }}-ingress-72
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: sheepdog-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.sheepdog-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: nv.revproxy-deployment.{{ .Release.Namespace }}-ingress-73
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: cert-manager.cert-manager
+      - key: domain
+        op: =
+        value: cert-manager
+      name: nv.cert-manager.cert-manager
+      original_name: ""
+  process:
+  - action: allow
+    allow_update: false
+    name: bash
+    path: /bin/bash
+  - action: allow
+    allow_update: false
+    name: curl
+    path: /usr/bin/curl
+  - action: allow
+    allow_update: false
+    name: nginx
+    path: /usr/sbin/nginx
+  - action: allow
+    allow_update: false
+    name: pause
+    path: /pause
+  - action: allow
+    allow_update: false
+    name: sh
+    path: /bin/dash
+  process_profile:
+    baseline: zero-drift
+  target:
+    policymode: {{ .Values.policies.policyMode }}
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: revproxy-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.revproxy-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  waf:
+    settings: []
+    status: true
+{{- end }}

--- a/helm/neuvector/templates/sheepdog-nvsecurityrule.yaml
+++ b/helm/neuvector/templates/sheepdog-nvsecurityrule.yaml
@@ -1,0 +1,184 @@
+{{- if .Values.policies.include }}
+apiVersion: neuvector.com/v1
+kind: NvSecurityRule
+metadata:
+  name: nv.sheepdog-deployment.{{ .Release.Namespace }}
+spec:
+  dlp:
+    settings: []
+    status: true
+  egress:
+  - action: allow
+    applications:
+    - DNS
+    name: nv.kube-dns.kube-system-egress-37
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: kube-dns.kube-system
+      - key: domain
+        op: =
+        value: kube-system
+      name: nv.kube-dns.kube-system
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    - SSL
+    name: external-egress-38
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria: []
+      name: external
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    - SSL
+    name: nv.{{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}-egress-39
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: {{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}
+      - key: domain
+        op: =
+        value: {{ .Values.ingress.class }}
+      name: nv.{{ .Values.ingress.controller }}.{{ .Values.ingress.namespace }}
+      original_name: ""
+  file: []
+  ingress:
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.sheepdog-deployment.{{ .Release.Namespace }}-ingress-74
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      name: Workload:ingress
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: nv.sheepdog-deployment.{{ .Release.Namespace }}-ingress-75
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria: []
+      name: external
+      original_name: ""
+  process:
+  - action: allow
+    allow_update: false
+    name: basename
+    path: /usr/bin/basename
+  - action: allow
+    allow_update: false
+    name: bash
+    path: /bin/bash
+  - action: allow
+    allow_update: false
+    name: chmod
+    path: /bin/chmod
+  - action: allow
+    allow_update: false
+    name: dockerrun.sh
+    path: /bin/dash
+  - action: allow
+    allow_update: false
+    name: find
+    path: /usr/bin/find
+  - action: allow
+    allow_update: false
+    name: ldconfig
+    path: /sbin/ldconfig
+  - action: allow
+    allow_update: false
+    name: mkdir
+    path: /bin/mkdir
+  - action: allow
+    allow_update: false
+    name: mv
+    path: /bin/mv
+  - action: allow
+    allow_update: false
+    name: nginx
+    path: /usr/sbin/nginx
+  - action: allow
+    allow_update: false
+    name: pause
+    path: /pause
+  - action: allow
+    allow_update: false
+    name: python
+    path: /usr/local/bin/python3.6
+  - action: allow
+    allow_update: false
+    name: python3
+    path: /usr/local/bin/python3.6
+  - action: allow
+    allow_update: false
+    name: readlink
+    path: /bin/readlink
+  - action: allow
+    allow_update: false
+    name: rm
+    path: /bin/rm
+  - action: allow
+    allow_update: false
+    name: run-parts
+    path: /bin/run-parts
+  - action: allow
+    allow_update: false
+    name: sed
+    path: /bin/sed
+  - action: allow
+    allow_update: false
+    name: sh
+    path: /bin/dash
+  - action: allow
+    allow_update: false
+    name: sort
+    path: /usr/bin/sort
+  - action: allow
+    allow_update: false
+    name: uname
+    path: /bin/uname
+  - action: allow
+    allow_update: false
+    name: uwsgi
+    path: /usr/local/bin/uwsgi
+  - action: allow
+    allow_update: false
+    name: wc
+    path: /usr/bin/wc
+  process_profile:
+    baseline: zero-drift
+  target:
+    policymode: {{ .Values.policies.policyMode }}
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: sheepdog-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.sheepdog-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  waf:
+    settings: []
+    status: true
+{{- end }}

--- a/helm/neuvector/templates/sower-nvsecurityrule.yaml
+++ b/helm/neuvector/templates/sower-nvsecurityrule.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.policies.include }}
+apiVersion: neuvector.com/v1
+kind: NvSecurityRule
+metadata:
+  name: nv.sower.{{ .Release.Namespace }}
+spec:
+  dlp:
+    settings: []
+    status: true
+  egress: []
+  file: []
+  ingress: []
+  process: []
+  process_profile:
+    baseline: zero-drift
+  target:
+    policymode: {{ .Values.policies.policyMode }}
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: sower.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.sower.{{ .Release.Namespace }}
+      original_name: ""
+  waf:
+    settings: []
+    status: true
+{{- end }}

--- a/helm/neuvector/templates/wts-nvsecurityrule.yaml
+++ b/helm/neuvector/templates/wts-nvsecurityrule.yaml
@@ -1,0 +1,199 @@
+{{- if .Values.policies.include }}
+apiVersion: neuvector.com/v1
+kind: NvSecurityRule
+metadata:
+  name: nv.wts-deployment.{{ .Release.Namespace }}
+spec:
+  dlp:
+    settings: []
+    status: true
+  egress:
+  - action: allow
+    applications:
+    - DNS
+    name: nv.kube-dns.kube-system-egress-2
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: kube-dns.kube-system
+      - key: domain
+        op: =
+        value: kube-system
+      name: nv.kube-dns.kube-system
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.fence-deployment.{{ .Release.Namespace }}-egress-3
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: fence-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.fence-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - PostgreSQL
+    name: nv.{{ .Values.DB_HOST }}.{{ .Release.Namespace }}-egress-4
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: {{ .Values.DB_HOST }}.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.{{ .Values.DB_HOST }}.{{ .Release.Namespace }}
+      original_name: ""
+  file: []
+  ingress:
+  - action: allow
+    applications:
+    - any
+    name: nv.wts-deployment.{{ .Release.Namespace }}-ingress-11
+    ports: tcp/80
+    priority: 0
+    selector:
+      comment: ""
+      name: Workload:ingress
+      original_name: ""
+  - action: allow
+    applications:
+    - SSL
+    name: nv.wts-deployment.{{ .Release.Namespace }}-ingress-12
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria: []
+      name: external
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.wts-deployment.{{ .Release.Namespace }}-ingress-13
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: revproxy-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.revproxy-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  - action: allow
+    applications:
+    - HTTP
+    name: nv.wts-deployment.{{ .Release.Namespace }}-ingress-14
+    ports: any
+    priority: 0
+    selector:
+      comment: ""
+      name: Workload:ingress
+      original_name: ""
+  process:
+  - action: allow
+    allow_update: false
+    name: alembic
+    path: /usr/local/bin/python3.9
+  - action: allow
+    allow_update: false
+    name: basename
+    path: /usr/bin/basename
+  - action: allow
+    allow_update: false
+    name: chmod
+    path: /bin/chmod
+  - action: allow
+    allow_update: false
+    name: dockerrun.sh
+    path: /bin/dash
+  - action: allow
+    allow_update: false
+    name: find
+    path: /usr/bin/find
+  - action: allow
+    allow_update: false
+    name: mkdir
+    path: /bin/mkdir
+  - action: allow
+    allow_update: false
+    name: mv
+    path: /bin/mv
+  - action: allow
+    allow_update: false
+    name: nginx
+    path: /usr/sbin/nginx
+  - action: allow
+    allow_update: false
+    name: pause
+    path: /pause
+  - action: allow
+    allow_update: false
+    name: readlink
+    path: /bin/readlink
+  - action: allow
+    allow_update: false
+    name: rm
+    path: /bin/rm
+  - action: allow
+    allow_update: false
+    name: run-parts
+    path: /bin/run-parts
+  - action: allow
+    allow_update: false
+    name: sed
+    path: /bin/sed
+  - action: allow
+    allow_update: false
+    name: sh
+    path: /bin/dash
+  - action: allow
+    allow_update: false
+    name: sort
+    path: /usr/bin/sort
+  - action: allow
+    allow_update: false
+    name: uwsgi
+    path: /usr/local/bin/uwsgi
+  - action: allow
+    allow_update: false
+    name: wc
+    path: /usr/bin/wc
+  process_profile:
+    baseline: zero-drift
+  target:
+    policymode: {{ .Values.policies.policyMode }}
+    selector:
+      comment: ""
+      criteria:
+      - key: service
+        op: =
+        value: wts-deployment.{{ .Release.Namespace }}
+      - key: domain
+        op: =
+        value: {{ .Release.Namespace }}
+      name: nv.wts-deployment.{{ .Release.Namespace }}
+      original_name: ""
+  waf:
+    settings: []
+    status: true
+{{- end }}

--- a/helm/neuvector/values.yaml
+++ b/helm/neuvector/values.yaml
@@ -16,6 +16,7 @@ policies:
 
 # hostname/service name for our DB
 DB_HOST: development-gen3-postgresql
+# hostname/service name for our ElasitcSearch instance
 ES_HOST: gen3-elasticsearch-master
 
 # Prefix for relevant services deployed through Argo

--- a/helm/neuvector/values.yaml
+++ b/helm/neuvector/values.yaml
@@ -1,0 +1,31 @@
+# Default values for neuvector.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+nameOverride: ""
+fullnameOverride: ""
+
+policies:
+  # deploy predefined Neuvector policies for Gen3
+  include: true
+  # Neuvector policy enforcement mode
+  # Discover, Monitor, or Protect
+  # dev: Monitor
+  # prod: Protect
+  policyMode: Monitor
+
+# hostname/service name for our DB
+DB_HOST: development-gen3-postgresql
+ES_HOST: gen3-elasticsearch-master
+
+# Prefix for relevant services deployed through Argo
+ARGOCD_PREFIX: development-gen3
+
+# Configure your ingress controller information for enabling ingress to containers
+ingress:
+  # service name of your ingress controller
+  controller: nginx-ingress-controller
+  # installation namespace of your ingress controller
+  namespace: nginx
+  # classname of your ingress
+  class: nginx

--- a/helm/wts/templates/wts-oidc.yaml
+++ b/helm/wts/templates/wts-oidc.yaml
@@ -91,7 +91,7 @@ spec:
               mountPath: "/var/www/fence/fence-config.yaml"
               subPath: fence-config.yaml
         - name: kubectl
-          #TODO: Make this configurable?  
+          #TODO: Make this configurable?
           image: bitnami/kubectl:latest
           volumeMounts:
             - name: "shared-volume"


### PR DESCRIPTION
# Changes

- Add chart containing Neuvector policies generated from a Gen3 platform in-use
  - Add values configurations to modify per your environment needs
  - Omitted Krum specifics
  - Added ability to upgrade policy enforcement modes
- Test manually.
  - By default, this will not interfere with your platform functionality since we will start in Discover or Monitor mode rather than Protect

## New Features
Default Security-as-Code templates that users may opt-in to install

## Dependency updates
Neuvector and Neuvector CRDs (if the subchart is enabled)

