### PR TITLE
Small fix for portal secret

### DIFF
--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -68,7 +68,7 @@ dependencies:
   repository: "file://../pidgin"
   condition: pidgin.enabled
 - name: portal
-  version: 0.1.13
+  version: 0.1.14
   repository: "file://../portal"
   condition: portal.enabled
 - name: requestor
@@ -119,7 +119,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.33
+version: 0.1.34
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -68,7 +68,7 @@ dependencies:
   repository: "file://../pidgin"
   condition: pidgin.enabled
 - name: portal
-  version: 0.1.12
+  version: 0.1.13
   repository: "file://../portal"
   condition: portal.enabled
 - name: requestor
@@ -119,7 +119,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.32
+version: 0.1.33
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/portal/Chart.yaml
+++ b/helm/portal/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.12
+version: 0.1.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/portal/Chart.yaml
+++ b/helm/portal/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.13
+version: 0.1.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/portal/templates/secret.yaml
+++ b/helm/portal/templates/secret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: portal-config
 data:
   {{- if .Values.gitops.createdby }}
-  gitops-createdby: |
+  gitops-createdby.png: |
     {{- .Values.gitops.createdby | nindent 4 }}
   {{- else }}
   gitops-createdby: |
@@ -19,10 +19,10 @@ data:
   {{- end }}
   {{- if .Values.gitops.favicon }}
   gitops-favicon.ico: |
-    {{- .Values.gitops.favicon | b64enc | nindent 4 }}
+    {{- .Values.gitops.favicon | nindent 4 }}
   {{- else }}
   gitops-favicon.ico: |
-    {{- (.Files.Get "defaults/gitops-favicon.ico" ) | nindent 4 }}
+    {{- (.Files.Get "defaults/gitops-favicon.ico" ) | b64enc) | nindent 4 }}
   {{- end }}
   {{- if .Values.gitops.json }}
   gitops.json: |

--- a/helm/portal/templates/secret.yaml
+++ b/helm/portal/templates/secret.yaml
@@ -7,7 +7,7 @@ data:
   gitops-createdby.png: |
     {{- .Values.gitops.createdby | nindent 4 }}
   {{- else }}
-  gitops-createdby: |
+  gitops-createdby.png: |
     {{- (.Files.Get "defaults/gitops-createdby.png" | b64enc) | nindent 4 }}
   {{- end }}
   {{- if .Values.gitops.css }}

--- a/helm/portal/templates/secret.yaml
+++ b/helm/portal/templates/secret.yaml
@@ -22,7 +22,7 @@ data:
     {{- .Values.gitops.favicon | nindent 4 }}
   {{- else }}
   gitops-favicon.ico: |
-    {{- (.Files.Get "defaults/gitops-favicon.ico" ) | b64enc) | nindent 4 }}
+    {{- (.Files.Get "defaults/gitops-favicon.ico" | b64enc) | nindent 4 }}
   {{- end }}
   {{- if .Values.gitops.json }}
   gitops.json: |


### PR DESCRIPTION
This PR fixes three very small issues with the secret template in the portal chart:

1. The `gitops-createdby` key is missing the file suffix (should be `gitops-createdby.png`).
2. The `gitops-favicon.ico` value is being base64 encoded if present (should only be indented).
3. The `gitops-favicon.ico` value is not being base64 encoded if taken from the default image file.

### Bug Fixes
- Small fixes to secret template for Portal (createdby and favicon)
- Bumps Portal chart from 0.1.13 to 0.1.14
- Bumps Gen3 umbrella chart from 0.1.33 to 0.1.34
