### PR TITLE
adding lgtm stack to gen3 helm charts

### DIFF
--- a/.github/workflows/lint_test.yaml
+++ b/.github/workflows/lint_test.yaml
@@ -33,7 +33,7 @@ jobs:
           fi
   
       - name: Helm Repo Update
-        run: helm repo update
+        run: helm repo update ./helm/lgtm-distributed
 
       - name: Run chart-testing (lint)
         run: ct lint --config .github/ct.yaml

--- a/.github/workflows/lint_test.yaml
+++ b/.github/workflows/lint_test.yaml
@@ -31,6 +31,9 @@ jobs:
           if [[ -n "$changed" ]]; then
             echo "changed=true >> $GITHUB_OUTPUT"
           fi
+  
+      - name: Helm Repo Update
+        run: helm repo update
 
       - name: Run chart-testing (lint)
         run: ct lint --config .github/ct.yaml

--- a/.github/workflows/lint_test.yaml
+++ b/.github/workflows/lint_test.yaml
@@ -31,9 +31,6 @@ jobs:
           if [[ -n "$changed" ]]; then
             echo "changed=true >> $GITHUB_OUTPUT"
           fi
-  
-      - name: Helm Repo Update
-        run: helm repo update ./helm/lgtm-distributed
 
       - name: Run chart-testing (lint)
         run: ct lint --config .github/ct.yaml

--- a/helm/lgtm-distributed/Chart.yaml
+++ b/helm/lgtm-distributed/Chart.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: v2
+name: lgtm-distributed
+description: Umbrella chart for a distributed Loki, Grafana, Tempo and Mimir stack
+type: application
+version: 1.0.1
+appVersion: "6.59.4"
+
+home: https://grafana.com/oss/
+icon: https://artifacthub.io/image/b4fed1a7-6c8f-4945-b99d-096efa3e4116
+
+sources:
+  - https://grafana.github.io/helm-charts
+  - https://github.com/grafana/grafana
+  - https://github.com/grafana/loki
+  - https://github.com/grafana/mimir
+  - https://github.com/grafana/tempo
+
+keywords:
+  - monitoring
+  - traces
+  - metrics
+  - logs
+
+annotations:
+  "artifacthub.io/license": Apache-2.0
+  "artifacthub.io/links": |
+    - name: Chart Source
+      url: https://github.com/grafana/helm-charts
+    - name: Grafana
+      url: https://github.com/grafana/grafana
+    - name: Loki
+      url: https://github.com/grafana/loki
+    - name: Mimir
+      url: https://github.com/grafana/mimir
+    - name: Tempo
+      url: https://github.com/grafana/tempo
+
+maintainers:
+  - name: timberhill
+
+dependencies:
+  - name: grafana
+    alias: grafana
+    condition: grafana.enabled
+    repository: https://grafana.github.io/helm-charts
+    version: "^7.3.9"
+  - name: loki-distributed
+    alias: loki
+    condition: loki.enabled
+    repository: "https://grafana.github.io/helm-charts"
+    version: "^0.74.3"
+  - name: mimir-distributed
+    alias: mimir
+    condition: mimir.enabled
+    repository: "https://grafana.github.io/helm-charts"
+    version: "^5.3.0"
+  - name: tempo-distributed
+    alias: tempo
+    condition: tempo.enabled
+    repository: "https://grafana.github.io/helm-charts"
+    version: "^1.9.9"

--- a/helm/lgtm-distributed/Chart.yaml
+++ b/helm/lgtm-distributed/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: lgtm-distributed
 description: Umbrella chart for a distributed Loki, Grafana, Tempo and Mimir stack
 type: application
-version: 1.0.1
+version: 1.0.0
 appVersion: "6.59.4"
 
 home: https://grafana.com/oss/

--- a/helm/lgtm-distributed/README.md
+++ b/helm/lgtm-distributed/README.md
@@ -1,6 +1,6 @@
 # lgtm-distributed
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.59.4](https://img.shields.io/badge/AppVersion-6.59.4-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.59.4](https://img.shields.io/badge/AppVersion-6.59.4-informational?style=flat-square)
 
 Umbrella chart for a distributed Loki, Grafana, Tempo and Mimir stack
 

--- a/helm/lgtm-distributed/README.md
+++ b/helm/lgtm-distributed/README.md
@@ -1,0 +1,44 @@
+# lgtm-distributed
+
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.59.4](https://img.shields.io/badge/AppVersion-6.59.4-informational?style=flat-square)
+
+Umbrella chart for a distributed Loki, Grafana, Tempo and Mimir stack
+
+**Homepage:** <https://grafana.com/oss/>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| timberhill |  |  |
+
+## Source Code
+
+* <https://grafana.github.io/helm-charts>
+* <https://github.com/grafana/grafana>
+* <https://github.com/grafana/loki>
+* <https://github.com/grafana/mimir>
+* <https://github.com/grafana/tempo>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://grafana.github.io/helm-charts | grafana(grafana) | ^7.3.9 |
+| https://grafana.github.io/helm-charts | loki(loki-distributed) | ^0.74.3 |
+| https://grafana.github.io/helm-charts | mimir(mimir-distributed) | ^5.3.0 |
+| https://grafana.github.io/helm-charts | tempo(tempo-distributed) | ^1.9.9 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| grafana.datasources | object | `{"datasources.yaml":{"apiVersion":1,"datasources":[{"isDefault":false,"name":"Loki","type":"loki","uid":"loki","url":"http://{{ .Release.Name }}-loki-gateway"},{"isDefault":true,"name":"Mimir","type":"prometheus","uid":"prom","url":"http://{{ .Release.Name }}-mimir-nginx/prometheus"},{"isDefault":false,"jsonData":{"lokiSearch":{"datasourceUid":"loki"},"serviceMap":{"datasourceUid":"prom"},"tracesToLogsV2":{"datasourceUid":"loki"},"tracesToMetrics":{"datasourceUid":"prom"}},"name":"Tempo","type":"tempo","uid":"tempo","url":"http://{{ .Release.Name }}-tempo-query-frontend:3100"}]}}` | Grafana data sources config. Connects to all three by default |
+| grafana.datasources."datasources.yaml".datasources | list | `[{"isDefault":false,"name":"Loki","type":"loki","uid":"loki","url":"http://{{ .Release.Name }}-loki-gateway"},{"isDefault":true,"name":"Mimir","type":"prometheus","uid":"prom","url":"http://{{ .Release.Name }}-mimir-nginx/prometheus"},{"isDefault":false,"jsonData":{"lokiSearch":{"datasourceUid":"loki"},"serviceMap":{"datasourceUid":"prom"},"tracesToLogsV2":{"datasourceUid":"loki"},"tracesToMetrics":{"datasourceUid":"prom"}},"name":"Tempo","type":"tempo","uid":"tempo","url":"http://{{ .Release.Name }}-tempo-query-frontend:3100"}]` | Datasources linked to the Grafana instance. Override if you disable any components. |
+| grafana.enabled | bool | `true` | Deploy Grafana if enabled. See [upstream readme](https://github.com/grafana/helm-charts/tree/main/charts/grafana#configuration) for full values reference. |
+| loki.enabled | bool | `true` | Deploy Loki if enabled. See [upstream readme](https://github.com/grafana/helm-charts/tree/main/charts/loki-distributed#values) for full values reference. |
+| mimir | object | `{"alertmanager":{"resources":{"requests":{"cpu":"20m"}}},"compactor":{"resources":{"requests":{"cpu":"20m"}}},"distributor":{"resources":{"requests":{"cpu":"20m"}}},"enabled":true,"ingester":{"replicas":2,"resources":{"requests":{"cpu":"20m"}},"zoneAwareReplication":{"enabled":false}},"minio":{"resources":{"requests":{"cpu":"20m"}}},"overrides_exporter":{"resources":{"requests":{"cpu":"20m"}}},"querier":{"replicas":1,"resources":{"requests":{"cpu":"20m"}}},"query_frontend":{"resources":{"requests":{"cpu":"20m"}}},"query_scheduler":{"replicas":1,"resources":{"requests":{"cpu":"20m"}}},"rollout_operator":{"resources":{"requests":{"cpu":"20m"}}},"ruler":{"resources":{"requests":{"cpu":"20m"}}},"store_gateway":{"resources":{"requests":{"cpu":"20m"}},"zoneAwareReplication":{"enabled":false}}}` | Mimir chart values. Resources are set to a minimum by default. |
+| mimir.enabled | bool | `true` | Deploy Mimir if enabled. See [upstream values.yaml](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/values.yaml) for full values reference. |
+| tempo.enabled | bool | `true` | Deploy Tempo if enabled.  See [upstream readme](https://github.com/grafana/helm-charts/blob/main/charts/tempo-distributed/README.md#values) for full values reference. |
+| tempo.ingester.replicas | int | `3` |  |
+

--- a/helm/lgtm-distributed/templates/NOTES.txt
+++ b/helm/lgtm-distributed/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Release name should be limited to 25 characters to not exceed the resource name limits of 63 characters.

--- a/helm/lgtm-distributed/templates/_helpers.tpl
+++ b/helm/lgtm-distributed/templates/_helpers.tpl
@@ -1,0 +1,18 @@
+ {{/*
+Create a default fully qualified app name without trimming it at all.
+If release name contains chart name it will be used as a full name.
+This value is essentially the same as "mimir.fullname" in the upstream chart.
+*/}}
+{{- define "mimir.fullname" -}}
+{{- if .Values.mimir.fullnameOverride -}}
+{{- .Values.mimir.fullnameOverride | trunc 25 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := .Values.mimir.nameOverride | default ( include "mimir.infixName" . ) | trunc 25 | trimSuffix "-" -}}
+{{- $releasename := .Release.Name | trunc 25 | trimSuffix "-" -}}
+{{- if contains $name .Release.Name -}}
+{{- $releasename -}}
+{{- else -}}
+{{- printf "%s-%s" $releasename $name -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/helm/lgtm-distributed/values.yaml
+++ b/helm/lgtm-distributed/values.yaml
@@ -1,0 +1,108 @@
+---
+grafana:
+  # -- Deploy Grafana if enabled. See [upstream readme](https://github.com/grafana/helm-charts/tree/main/charts/grafana#configuration) for full values reference.
+  enabled: true
+
+  # -- Grafana data sources config. Connects to all three by default
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      # -- Datasources linked to the Grafana instance. Override if you disable any components.
+      datasources:
+        # https://grafana.com/docs/grafana/latest/datasources/loki/#provision-the-loki-data-source
+        - name: Loki
+          uid: loki
+          type: loki
+          url: http://{{ .Release.Name }}-loki-gateway
+          isDefault: false
+        # https://grafana.com/docs/grafana/latest/datasources/prometheus/#provision-the-data-source
+        - name: Mimir
+          uid: prom
+          type: prometheus
+          url: http://{{ .Release.Name }}-mimir-nginx/prometheus
+          isDefault: true
+        # https://grafana.com/docs/grafana/latest/datasources/tempo/configure-tempo-data-source/#provision-the-data-source
+        - name: Tempo
+          uid: tempo
+          type: tempo
+          url: http://{{ .Release.Name }}-tempo-query-frontend:3100
+          isDefault: false
+          jsonData:
+            tracesToLogsV2:
+              datasourceUid: loki
+            lokiSearch:
+              datasourceUid: loki
+            tracesToMetrics:
+              datasourceUid: prom
+            serviceMap:
+              datasourceUid: prom
+
+loki:
+  # -- Deploy Loki if enabled. See [upstream readme](https://github.com/grafana/helm-charts/tree/main/charts/loki-distributed#values) for full values reference.
+  enabled: true
+
+# -- Mimir chart values. Resources are set to a minimum by default.
+mimir:
+  # -- Deploy Mimir if enabled. See [upstream values.yaml](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/values.yaml) for full values reference.
+  enabled: true
+  alertmanager:
+    resources:
+      requests:
+        cpu: 20m
+  compactor:
+    resources:
+      requests:
+        cpu: 20m
+  distributor:
+    resources:
+      requests:
+        cpu: 20m
+  ingester:
+    replicas: 2
+    zoneAwareReplication:
+      enabled: false
+    resources:
+      requests:
+        cpu: 20m
+  overrides_exporter:
+    resources:
+      requests:
+        cpu: 20m
+  querier:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 20m
+  query_frontend:
+    resources:
+      requests:
+        cpu: 20m
+  query_scheduler:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 20m
+  ruler:
+    resources:
+      requests:
+        cpu: 20m
+  store_gateway:
+    zoneAwareReplication:
+      enabled: false
+    resources:
+      requests:
+        cpu: 20m
+  minio:
+    resources:
+      requests:
+        cpu: 20m
+  rollout_operator:
+    resources:
+      requests:
+        cpu: 20m
+
+tempo:
+  # -- Deploy Tempo if enabled.  See [upstream readme](https://github.com/grafana/helm-charts/blob/main/charts/tempo-distributed/README.md#values) for full values reference.
+  enabled: true
+  ingester:
+    replicas: 3


### PR DESCRIPTION
### New Features
We are adding in a Grafana stack to our gen3 helm charts, so they can be used as open source monitoring for our gen3 data commons. 