### PR TITLE
adding a helm dependency update linter

### DIFF
--- a/.github/workflows/lint_test.yaml
+++ b/.github/workflows/lint_test.yaml
@@ -36,7 +36,7 @@ jobs:
         run: ct lint --config .github/ct.yaml
 
       - name: Helm dependency update Umbrella chart
-        run: helm dependency update ./helm/gen3-helm
+        run: helm dependency update helm/gen3
       
   # TODO: add back in when we have tests
   # deploy-and-test-chart:

--- a/.github/workflows/lint_test.yaml
+++ b/.github/workflows/lint_test.yaml
@@ -34,6 +34,9 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: ct lint --config .github/ct.yaml
+
+      - name: Helm dependency update Umbrella chart
+        run: helm dependency update ./helm/gen3-helm
       
   # TODO: add back in when we have tests
   # deploy-and-test-chart:

--- a/helm/common/Chart.yaml
+++ b/helm/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.10
+version: 0.1.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/common/README.md
+++ b/helm/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.11](https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for provisioning databases in gen3
 

--- a/helm/common/templates/_aws_config.tpl
+++ b/helm/common/templates/_aws_config.tpl
@@ -1,5 +1,5 @@
 {{/*
-    Credentials for all AWS stuff.
+    Credentials for all AWS stuff. TEST
 */}}
 {{ define "common.awsconfig" -}}
 apiVersion: v1

--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
   repository: "file://../aws-es-proxy"
   condition: aws-es-proxy.enabled
 - name: common
-  version: 0.1.10
+  version: 0.1.11
   repository: file://../common
 - name: etl
   version: 0.1.1
@@ -119,7 +119,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.33
+version: 0.1.34
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/gen3/README.md
+++ b/helm/gen3/README.md
@@ -1,6 +1,6 @@
 # gen3
 
-![Version: 0.1.33](https://img.shields.io/badge/Version-0.1.33-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.34](https://img.shields.io/badge/Version-0.1.34-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 Helm chart to deploy Gen3 Data Commons
 
@@ -23,7 +23,7 @@ Helm chart to deploy Gen3 Data Commons
 | file://../argo-wrapper | argo-wrapper | 0.1.7 |
 | file://../audit | audit | 0.1.12 |
 | file://../aws-es-proxy | aws-es-proxy | 0.1.9 |
-| file://../common | common | 0.1.10 |
+| file://../common | common | 0.1.11 |
 | file://../etl | etl | 0.1.1 |
 | file://../fence | fence | 0.1.18 |
 | file://../frontend-framework | frontend-framework | 0.1.1 |

--- a/helm/portal/Chart.yaml
+++ b/helm/portal/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.13
+version: 0.1.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/portal/README.md
+++ b/helm/portal/README.md
@@ -1,6 +1,6 @@
 # portal
 
-![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.14](https://img.shields.io/badge/Version-0.1.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for gen3 data-portal
 

--- a/helm/portal/templates/secret.yaml
+++ b/helm/portal/templates/secret.yaml
@@ -42,7 +42,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: portal-sponsor-config
+  name: portal-sponsor-config-test
 data:
 {{- range $key, $value := .Values.gitops.sponsors }}
   {{ $key }}: {{ $value  }}


### PR DESCRIPTION
### Improvements
adding a helm dependency update linter for the gen3 umbrella chart, so we don't miss updating a subcharts version. 

