### PR TITLE
Add nodeSelector to portal

### DIFF
--- a/helm/portal/templates/deployment.yaml
+++ b/helm/portal/templates/deployment.yaml
@@ -30,6 +30,10 @@ spec:
         {{- include "common.datadogLabels" . | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
### Bug Fixes
`nodeSelector` is in the values.yaml for the portal subchart, but not in the deployment template itself. This adds the value to the template so that it works as expected given its inclusion in the values.yaml
