### PR TITLE
Opt-out useryaml when using usersync

### DIFF
--- a/docs/fence_usersync_job.md
+++ b/docs/fence_usersync_job.md
@@ -1,6 +1,6 @@
 # Fence Usersync CronJob
 
-If `.Values.usersync.usersync` is set to true, the Fence usersync-cron.yaml will be deployed to the cluster.
+If `.Values.usersync.usersync` is set to true, the Fence usersync-cron.yaml will be deployed to the cluster, otherwise useryaml job will be deployed instead of usersync.
 
 User lists can be synced from three sources:
 

--- a/helm/common/Chart.yaml
+++ b/helm/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.11
+version: 0.1.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/fence/Chart.yaml
+++ b/helm/fence/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.19
+version: 0.1.20
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,7 +24,7 @@ appVersion: "master"
 
 dependencies:
 - name: common
-  version: 0.1.11
+  version: 0.1.12
   repository: file://../common
 - name: postgresql
   version: 11.9.13

--- a/helm/fence/templates/useryaml-job.yaml
+++ b/helm/fence/templates/useryaml-job.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.usersync.usersync }}
 kind: ConfigMap 
 apiVersion: v1 
 metadata:
@@ -47,3 +48,4 @@ spec:
             # can be removed once this is merged: https://github.com/uc-cdis/fence/pull/1096
             fence-create sync --arborist http://arborist-service --yaml /var/www/fence/user.yaml
       restartPolicy: OnFailure
+{{ end }}

--- a/helm/fence/values.yaml
+++ b/helm/fence/values.yaml
@@ -100,7 +100,7 @@ externalSecrets:
 # -- (map) Configuration options for usersync cronjob.
 usersync:
   # -- (bool) Whether to run Fence usersync or not.
-  usersync: true
+  usersync: false
   # -- (string) The cron schedule expression to use in the usersync cronjob. Runs every 30 minutes by default.
   schedule: "*/30 * * * *"
   # -- (string) To set a custom image for pulling the user.yaml file from S3. Default is the Gen3 Awshelper image.

--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
   repository: "file://../aws-es-proxy"
   condition: aws-es-proxy.enabled
 - name: common
-  version: 0.1.11
+  version: 0.1.12
   repository: file://../common
 - name: etl
   version: 0.1.1
@@ -36,7 +36,7 @@ dependencies:
   repository: "file://../frontend-framework"
   condition: frontend-framework.enabled
 - name: fence
-  version: 0.1.19
+  version: 0.1.20
   repository: "file://../fence"
   condition: fence.enabled
 - name: guppy
@@ -128,7 +128,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.38
+version: 0.1.39
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: 

### New Features

Option to disabled redundant useryaml job when usersync is deployed. Only one of these will be deployed not both.
