### PR TITLE
Change HOSTNAME of frontend-framework

### DIFF
--- a/helm/frontend-framework/Chart.yaml
+++ b/helm/frontend-framework/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/frontend-framework/README.md
+++ b/helm/frontend-framework/README.md
@@ -1,6 +1,6 @@
 # frontend-framework
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: develop](https://img.shields.io/badge/AppVersion-develop-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: develop](https://img.shields.io/badge/AppVersion-develop-informational?style=flat-square)
 
 A Helm chart for the gen3 frontend framework
 

--- a/helm/frontend-framework/templates/deployment.yaml
+++ b/helm/frontend-framework/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             - name: PORT
               value: {{ .Values.port | quote }}
             - name: HOSTNAME
-              value: revproxy-service
+              value: "0.0.0.0"
             {{- if eq "portal" .Values.global.frontendRoot }}
             - name: BASE_PATH
               value: /ff
@@ -79,4 +79,4 @@ spec:
             - name: NEXT_PUBLIC_PORTAL_BASENAME
               value: /portal
             {{- end }}
-              
+


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: 

Changes the hostname for the frontend deployment from rev-proxy to 0.0.0.0. This allows the NextJS standalone server to be used, resulting in a much smaller docker image.

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
