### PR TITLE
making the cred-volume optional

### DIFF
--- a/helm/fence/Chart.yaml
+++ b/helm/fence/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.27
+version: 0.1.28
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/fence/templates/usersync-cron.yaml
+++ b/helm/fence/templates/usersync-cron.yaml
@@ -56,6 +56,7 @@ spec:
               emptyDir: {}
             - name: cred-volume
               secret:
+                optional: true
               {{- if .Values.global.aws.useLocalSecret.enabled }}
                 secretName: {{ .Values.global.aws.useLocalSecret.localSecretName }}
               {{- else }}

--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -128,7 +128,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.55
+version: 0.1.56
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -36,7 +36,7 @@ dependencies:
     repository: "file://../frontend-framework"
     condition: frontend-framework.enabled
   - name: fence
-    version: 0.1.27
+    version: 0.1.28
     repository: "file://../fence"
     condition: fence.enabled
   - name: guppy


### PR DESCRIPTION
### Improvements
Some environments rely on the ec2 worker role for access to the user.yaml file, so this volume should be optional. 

