### PR TITLE
support AWS creds as env vars (for deployment outside EKS)

### DIFF
--- a/helm/manifestservice/templates/deployment.yaml
+++ b/helm/manifestservice/templates/deployment.yaml
@@ -42,6 +42,18 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             {{- toYaml .Values.env | nindent 12 }}
+            {{- if and .Values.manifestserviceG3auto.awsaccesskey .Values.manifestserviceG3auto.awssecretkey }}
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: manifestservice-g3auto
+                  key: aws_access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: manifestservice-g3auto
+                  key: aws_secret_access_key
+            {{- end }}
           volumeMounts:
             {{- toYaml .Values.volumeMounts | nindent 12 }}
           resources:

--- a/helm/manifestservice/templates/manifestservice-creds.yaml
+++ b/helm/manifestservice/templates/manifestservice-creds.yaml
@@ -15,4 +15,9 @@ stringData:
         {{ end }}
         "prefix": "{{ .Values.manifestserviceG3auto.prefix }}"
       }
+data:
+  {{- if and .Values.manifestserviceG3auto.awsaccesskey .Values.manifestserviceG3auto.awssecretkey }}
+  aws_access_key_id: {{ .Values.manifestserviceG3auto.awsaccesskey | b64enc | quote }}
+  aws_secret_access_key: {{ .Values.manifestserviceG3auto.awssecretkey | b64enc | quote }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
**Context**
I'm deploying Gen3 using `helm` but outside of EKS. [As noted](https://github.com/uc-cdis/manifestservice/blob/master/docs/credentials_breaking_change.md) in the `manifestservice` documentation, [5daffd6](https://github.com/uc-cdis/manifestservice/commit/5daffd6) removed support for AWS credentials read from the `/var/gen3/config/config.json` file. As further suggested in that doc, a workaround for non-EKS users is to export the credentials to environment variables in the pod container. This PR is implementing the change for helm deployments foreshadowed in the doc [here](https://github.com/uc-cdis/manifestservice/blob/master/docs/credentials_breaking_change.md#non-eks-users:~:text=In%20future%20iterations%2C%20we%20aim%20to%20include%20this%20feature%20in%20the%20Helm%20chart%20deployment%20to%20simplify%20the%20process.)

**Motivation**
I want to deploy Gen3 outside of EKS context (e.g. for dev work on a local k8s cluster) and therefore can't use IRSA for auth. I want to use the environment variable workaround suggested in the documentation, with a simple helm deployment.

**Overview**
This PR uses the existing `awsaccesskey` and `awssecretkey` configuration points under `manifestservice.manifestserviceG3auto` to set optional environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` which will be used for credentials by calls without auth arguments to `boto3.Session()`, as for example in [`manifestservice.manifests.__init__.py`](https://github.com/uc-cdis/manifestservice/blob/7ce622355445b38ecacfc770e9209ea26f23ca3c/manifestservice/manifests/__init__.py#L308).

If the key id and secret are not both present, the environment vars are not set.

**Discussion**
In the interests of a minimal change this PR does not remove AWS credentials written into `config.json` at `MANIFEST_SERVICE_CONFIG_PATH`, even though they do not appear to be used any more by `manifestservice` since [5daffd6](https://github.com/uc-cdis/manifestservice/commit/5daffd61259c3183a648d850d5053a48b0c69abc#diff-b08ccaa355ce7e4fe748d3ecfdfe1c41c7fdaf92426378cd6d5ae8445495c32dL40) removed them from `manifestservice.api.app.config`. But perhaps they should be removed from [here](https://github.com/uc-cdis/gen3-helm/blob/95a35537a7cbb8e8174a6f65ada37a471bd076ee/helm/manifestservice/templates/manifestservice-creds.yaml#L12-L15) to reduce cruft? Is anyone relying on them being there?

### New Features
* Export AWS credentials to `manifestservice` env vars to support non-EKS deployment

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
