### PR TITLE
Updating default sower configuration. 

### DIFF
--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -88,7 +88,7 @@ dependencies:
     repository: "file://../ssjdispatcher"
     condition: ssjdispatcher.enabled
   - name: sower
-    version: 0.1.18
+    version: 0.1.19
     condition: sower.enabled
     repository: "file://../sower"
   - name: wts
@@ -132,7 +132,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.63
+version: 0.1.64
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/gen3/README.md
+++ b/helm/gen3/README.md
@@ -1,6 +1,6 @@
 # gen3
 
-![Version: 0.1.63](https://img.shields.io/badge/Version-0.1.63-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.64](https://img.shields.io/badge/Version-0.1.64-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 Helm chart to deploy Gen3 Data Commons
 
@@ -40,7 +40,7 @@ Helm chart to deploy Gen3 Data Commons
 | file://../requestor | requestor | 0.1.17 |
 | file://../revproxy | revproxy | 0.1.23 |
 | file://../sheepdog | sheepdog | 0.1.21 |
-| file://../sower | sower | 0.1.18 |
+| file://../sower | sower | 0.1.19 |
 | file://../ssjdispatcher | ssjdispatcher | 0.1.19 |
 | file://../wts | wts | 0.1.19 |
 | https://charts.bitnami.com/bitnami | postgresql | 11.9.13 |
@@ -166,6 +166,7 @@ Helm chart to deploy Gen3 Data Commons
 | secrets.awsAccessKeyId | str | `nil` | AWS access key ID. Overrides global key. |
 | secrets.awsSecretAccessKey | str | `nil` | AWS secret access key ID. Overrides global key. |
 | sheepdog.enabled | bool | `true` | Whether to deploy the sheepdog subchart. |
+| sower.enabled | bool | `false` | Whether to deploy the sower subchart. |
 | ssjdispatcher.enabled | bool | `false` | Whether to deploy the ssjdispatcher subchart. |
 | tests | map | `{"SERVICE_TO_TEST":null,"TEST_LABEL":null,"image":{"tag":null},"resources":{"limits":{"cpu":"1","memory":"10G"},"requests":{"cpu":"1","memory":"6G"}}}` | Environment variables that control which tests are run. |
 | tests.SERVICE_TO_TEST | str | `nil` | Name of the service we are testing. Default is empty as GH workflow automatically sets this. |

--- a/helm/gen3/values.yaml
+++ b/helm/gen3/values.yaml
@@ -283,6 +283,10 @@ wts:
   # -- (bool) Whether to deploy the wts subchart.
   enabled: true
 
+sower:
+  # -- (bool) Whether to deploy the sower subchart.
+  enabled: false
+
 # -- (map) To configure postgresql subchart
 # Disable persistence by default so we can spin up and down ephemeral environments
 postgresql:

--- a/helm/sower/Chart.yaml
+++ b/helm/sower/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.18
+version: 0.1.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/sower/README.md
+++ b/helm/sower/README.md
@@ -1,6 +1,6 @@
 # sower
 
-![Version: 0.1.18](https://img.shields.io/badge/Version-0.1.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.19](https://img.shields.io/badge/Version-0.1.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for gen3 sower
 
@@ -77,6 +77,7 @@ A Helm chart for gen3 sower
 | netPolicy.ingressApps | array | `["pidgin"]` | List of app labels that require ingress to this service |
 | nodeSelector | map | `{}` | Node Selector for the pods |
 | partOf | string | `"Core-Service"` | Label to help organize pods and their use. Any value is valid, but use "_" or "-" to divide words. |
+| pelican.bucket | string | `"sower-pfb-bucket"` |  |
 | podSecurityContext | map | `{"fsGroup":1000,"runAsUser":1000}` | Security context to apply to the pod |
 | podSecurityContext.fsGroup | int | `1000` | Group that Kubernetes will change the permissions of all files in volumes to when volumes are mounted by a pod. |
 | podSecurityContext.runAsUser | int | `1000` | User that all the processes will run under in the container. |
@@ -112,16 +113,16 @@ A Helm chart for gen3 sower
 | sowerConfig[0].container.env[2].value | string | `"subject"` |  |
 | sowerConfig[0].container.env[3].name | string | `"DB_HOST"` |  |
 | sowerConfig[0].container.env[3].valueFrom.secretKeyRef.key | string | `"host"` |  |
-| sowerConfig[0].container.env[3].valueFrom.secretKeyRef.name | string | `"peregrine-dbcreds"` |  |
+| sowerConfig[0].container.env[3].valueFrom.secretKeyRef.name | string | `"sheepdog-dbcreds"` |  |
 | sowerConfig[0].container.env[4].name | string | `"DB_DATABASE"` |  |
 | sowerConfig[0].container.env[4].valueFrom.secretKeyRef.key | string | `"database"` |  |
-| sowerConfig[0].container.env[4].valueFrom.secretKeyRef.name | string | `"peregrine-dbcreds"` |  |
+| sowerConfig[0].container.env[4].valueFrom.secretKeyRef.name | string | `"sheepdog-dbcreds"` |  |
 | sowerConfig[0].container.env[5].name | string | `"DB_USER"` |  |
 | sowerConfig[0].container.env[5].valueFrom.secretKeyRef.key | string | `"username"` |  |
-| sowerConfig[0].container.env[5].valueFrom.secretKeyRef.name | string | `"peregrine-dbcreds"` |  |
+| sowerConfig[0].container.env[5].valueFrom.secretKeyRef.name | string | `"sheepdog-dbcreds"` |  |
 | sowerConfig[0].container.env[6].name | string | `"DB_PASS"` |  |
 | sowerConfig[0].container.env[6].valueFrom.secretKeyRef.key | string | `"password"` |  |
-| sowerConfig[0].container.env[6].valueFrom.secretKeyRef.name | string | `"peregrine-dbcreds"` |  |
+| sowerConfig[0].container.env[6].valueFrom.secretKeyRef.name | string | `"sheepdog-dbcreds"` |  |
 | sowerConfig[0].container.env[7].name | string | `"SHEEPDOG"` |  |
 | sowerConfig[0].container.env[7].valueFrom.secretKeyRef.key | string | `"sheepdog"` |  |
 | sowerConfig[0].container.env[7].valueFrom.secretKeyRef.name | string | `"indexd-service-creds"` |  |
@@ -151,16 +152,16 @@ A Helm chart for gen3 sower
 | sowerConfig[1].container.env[3].value | string | `""` |  |
 | sowerConfig[1].container.env[4].name | string | `"DB_HOST"` |  |
 | sowerConfig[1].container.env[4].valueFrom.secretKeyRef.key | string | `"host"` |  |
-| sowerConfig[1].container.env[4].valueFrom.secretKeyRef.name | string | `"peregrine-dbcreds"` |  |
+| sowerConfig[1].container.env[4].valueFrom.secretKeyRef.name | string | `"sheepdog-dbcreds"` |  |
 | sowerConfig[1].container.env[5].name | string | `"DB_DATABASE"` |  |
 | sowerConfig[1].container.env[5].valueFrom.secretKeyRef.key | string | `"database"` |  |
-| sowerConfig[1].container.env[5].valueFrom.secretKeyRef.name | string | `"peregrine-dbcreds"` |  |
+| sowerConfig[1].container.env[5].valueFrom.secretKeyRef.name | string | `"sheepdog-dbcreds"` |  |
 | sowerConfig[1].container.env[6].name | string | `"DB_USER"` |  |
 | sowerConfig[1].container.env[6].valueFrom.secretKeyRef.key | string | `"username"` |  |
-| sowerConfig[1].container.env[6].valueFrom.secretKeyRef.name | string | `"peregrine-dbcreds"` |  |
+| sowerConfig[1].container.env[6].valueFrom.secretKeyRef.name | string | `"sheepdog-dbcreds"` |  |
 | sowerConfig[1].container.env[7].name | string | `"DB_PASS"` |  |
 | sowerConfig[1].container.env[7].valueFrom.secretKeyRef.key | string | `"password"` |  |
-| sowerConfig[1].container.env[7].valueFrom.secretKeyRef.name | string | `"peregrine-dbcreds"` |  |
+| sowerConfig[1].container.env[7].valueFrom.secretKeyRef.name | string | `"sheepdog-dbcreds"` |  |
 | sowerConfig[1].container.env[8].name | string | `"SHEEPDOG"` |  |
 | sowerConfig[1].container.env[8].valueFrom.secretKeyRef.key | string | `"sheepdog"` |  |
 | sowerConfig[1].container.env[8].valueFrom.secretKeyRef.name | string | `"indexd-service-creds"` |  |
@@ -172,10 +173,6 @@ A Helm chart for gen3 sower
 | sowerConfig[1].container.volumeMounts[0].name | string | `"pelican-creds-volume"` |  |
 | sowerConfig[1].container.volumeMounts[0].readOnly | bool | `true` |  |
 | sowerConfig[1].container.volumeMounts[0].subPath | string | `"config.json"` |  |
-| sowerConfig[1].container.volumeMounts[1].mountPath | string | `"/peregrine-creds.json"` |  |
-| sowerConfig[1].container.volumeMounts[1].name | string | `"peregrine-creds-volume"` |  |
-| sowerConfig[1].container.volumeMounts[1].readOnly | bool | `true` |  |
-| sowerConfig[1].container.volumeMounts[1].subPath | string | `"creds.json"` |  |
 | sowerConfig[1].name | string | `"pelican-export-files"` |  |
 | sowerConfig[1].restart_policy | string | `"Never"` |  |
 | sowerConfig[1].volumes[0].name | string | `"pelican-creds-volume"` |  |

--- a/helm/sower/templates/pelican-creds.yaml
+++ b/helm/sower/templates/pelican-creds.yaml
@@ -4,7 +4,6 @@ kind: Secret
 metadata:
   name: pelicanservice-g3auto
 type: Opaque
-{{- if .Values.global.aws.enabled }}
 stringData:
   config.json: |
     {
@@ -13,5 +12,4 @@ stringData:
       "aws_access_key_id": "{{ .Values.secrets.awsAccessKeyId | default .Values.global.aws.awsAccessKeyId }}",
       "aws_secret_access_key": "{{ .Values.secrets.awsSecretAccessKey | default .Values.global.aws.awsSecretAccessKey }}"
     }
-{{- end }}
 {{- end }}

--- a/helm/sower/values.yaml
+++ b/helm/sower/values.yaml
@@ -244,25 +244,26 @@ sowerConfig:
               key: hostname
         - name: ROOT_NODE
           value: subject
+        #TO DO- make a separate pelican user to access sheepdog.
         - name: DB_HOST
           valueFrom:
             secretKeyRef:
-              name: peregrine-dbcreds
+              name: sheepdog-dbcreds
               key: host
         - name: DB_DATABASE
           valueFrom:
             secretKeyRef:
-              name: peregrine-dbcreds
+              name: sheepdog-dbcreds
               key: database
         - name: DB_USER
           valueFrom:
             secretKeyRef:
-              name: peregrine-dbcreds
+              name: sheepdog-dbcreds
               key: username
         - name: DB_PASS
           valueFrom:
             secretKeyRef:
-              name: peregrine-dbcreds
+              name: sheepdog-dbcreds
               key: password
         - name: SHEEPDOG
           valueFrom:
@@ -305,22 +306,22 @@ sowerConfig:
         - name: DB_HOST
           valueFrom:
             secretKeyRef:
-              name: peregrine-dbcreds
+              name: sheepdog-dbcreds
               key: host
         - name: DB_DATABASE
           valueFrom:
             secretKeyRef:
-              name: peregrine-dbcreds
+              name: sheepdog-dbcreds
               key: database
         - name: DB_USER
           valueFrom:
             secretKeyRef:
-              name: peregrine-dbcreds
+              name: sheepdog-dbcreds
               key: username
         - name: DB_PASS
           valueFrom:
             secretKeyRef:
-              name: peregrine-dbcreds
+              name: sheepdog-dbcreds
               key: password
         - name: SHEEPDOG
           valueFrom:
@@ -332,10 +333,6 @@ sowerConfig:
           readOnly: true
           mountPath: "/pelican-creds.json"
           subPath: config.json
-        - name: peregrine-creds-volume
-          readOnly: true
-          mountPath: "/peregrine-creds.json"
-          subPath: creds.json
       cpu-limit: "1"
       memory-limit: 12Gi
     volumes:
@@ -343,6 +340,9 @@ sowerConfig:
         secret:
           secretName: pelicanservice-g3auto
     restart_policy: Never
+
+pelican:
+  bucket: "sower-pfb-bucket"
 
 # -- (string) Additional configuration for Sower Jobs Passed in as a multiline string. This secret can be mounted in sowerConfig.
 sowerjobsG3auto: |

--- a/helm/sower/values.yaml
+++ b/helm/sower/values.yaml
@@ -244,7 +244,7 @@ sowerConfig:
               key: hostname
         - name: ROOT_NODE
           value: subject
-        #TO DO- make a separate pelican user to access sheepdog.
+        # TO DO- make a separate pelican user to access sheepdog.
         - name: DB_HOST
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
### Improvements
- Making updates to sower jobs so the default configuration works with PFB and Pelican batch export jobs. 

- Pelican-creds only works with AWS atm, so I removed the logic to enable aws so we can test in CI with localstack.

- Disabled sower by default in gen3 helm chart and add a default pelican bucket.