### PR TITLE
updating orthanc and dicom charts to not require the db creds

### DIFF
--- a/helm/dicom-server/Chart.yaml
+++ b/helm/dicom-server/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.15
+version: 0.1.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/dicom-server/README.md
+++ b/helm/dicom-server/README.md
@@ -1,6 +1,6 @@
 # dicom-server
 
-![Version: 0.1.15](https://img.shields.io/badge/Version-0.1.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.16](https://img.shields.io/badge/Version-0.1.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for gen3 Dicom Server
 

--- a/helm/dicom-server/templates/deployment.yaml
+++ b/helm/dicom-server/templates/deployment.yaml
@@ -58,31 +58,31 @@ spec:
                 secretKeyRef:
                   name: dicom-server-dbcreds
                   key: host
-                  optional: false 
+                  optional: true
             - name: PGUSER
               valueFrom:
                 secretKeyRef:
                   name: dicom-server-dbcreds
                   key: username
-                  optional: false 
+                  optional: true 
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:
                   name: dicom-server-dbcreds
                   key: password
-                  optional: false
+                  optional: true
             - name: PGDB
               valueFrom:
                 secretKeyRef:
                   name: dicom-server-dbcreds
                   key: database
-                  optional: false
+                  optional: true
             - name: DBREADY
               valueFrom:
                 secretKeyRef:
                   name: dicom-server-dbcreds
                   key: dbcreated
-                  optional: false
+                  optional: true
           {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 10 }}

--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -116,7 +116,7 @@ dependencies:
     repository: "file://../gen3-network-policies"
     condition: global.netPolicy.enabled
   - name: dicom-server
-    version: 0.1.15
+    version: 0.1.16
     repository: file://../dicom-server
     condition: dicom-server.enabled
   - name: ohif-viewer
@@ -124,7 +124,7 @@ dependencies:
     repository: file://../ohif-viewer
     condition: ohif-viewer.enabled
   - name: orthanc
-    version: 0.1.0
+    version: 0.1.1
     repository: file://../orthanc
     condition: orthanc.enabled
 
@@ -160,7 +160,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.95
+version: 0.1.96
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/gen3/README.md
+++ b/helm/gen3/README.md
@@ -1,6 +1,6 @@
 # gen3
 
-![Version: 0.1.95](https://img.shields.io/badge/Version-0.1.95-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.96](https://img.shields.io/badge/Version-0.1.96-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 Helm chart to deploy Gen3 Data Commons
 
@@ -28,7 +28,7 @@ Helm chart to deploy Gen3 Data Commons
 | file://../cohort-middleware | cohort-middleware | 0.1.6 |
 | file://../common | common | 0.1.20 |
 | file://../dashboard | dashboard | 0.1.1 |
-| file://../dicom-server | dicom-server | 0.1.15 |
+| file://../dicom-server | dicom-server | 0.1.16 |
 | file://../etl | etl | 0.1.12 |
 | file://../fence | fence | 0.1.41 |
 | file://../frontend-framework | frontend-framework | 0.1.11 |
@@ -41,7 +41,7 @@ Helm chart to deploy Gen3 Data Commons
 | file://../metadata | metadata | 0.1.25 |
 | file://../neuvector | neuvector | 0.1.2 |
 | file://../ohif-viewer | ohif-viewer | 0.1.0 |
-| file://../orthanc | orthanc | 0.1.0 |
+| file://../orthanc | orthanc | 0.1.1 |
 | file://../peregrine | peregrine | 0.1.25 |
 | file://../portal | portal | 0.1.34 |
 | file://../requestor | requestor | 0.1.21 |

--- a/helm/orthanc/Chart.yaml
+++ b/helm/orthanc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/orthanc/README.md
+++ b/helm/orthanc/README.md
@@ -1,6 +1,6 @@
 # orthanc
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for gen3 Dicom Server
 

--- a/helm/orthanc/templates/deployment.yaml
+++ b/helm/orthanc/templates/deployment.yaml
@@ -65,31 +65,31 @@ spec:
                 secretKeyRef:
                   name: orthanc-dbcreds
                   key: host
-                  optional: false 
+                  optional: true 
             - name: PGUSER
               valueFrom:
                 secretKeyRef:
                   name: orthanc-dbcreds
                   key: username
-                  optional: false 
+                  optional: true 
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:
                   name: orthanc-dbcreds
                   key: password
-                  optional: false
+                  optional: true
             - name: PGDB
               valueFrom:
                 secretKeyRef:
                   name: orthanc-dbcreds
                   key: database
-                  optional: false
+                  optional: true
             - name: DBREADY
               valueFrom:
                 secretKeyRef:
                   name: orthanc-dbcreds
                   key: dbcreated
-                  optional: false
+                  optional: true
             - name: DICOM_WEB_PLUGIN_ENABLED
               value: "true"
             - name: TCIA_PLUGIN_ENABLED


### PR DESCRIPTION
db creds can be set directly in external secrets so they should be "optional" in the deployment as env vars.