### PR TITLE
reverting PFB changes.

### DIFF
--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -104,7 +104,7 @@ dependencies:
     repository: "file://../ssjdispatcher"
     condition: ssjdispatcher.enabled
   - name: sower
-    version: 0.1.25
+    version: 0.1.26
     condition: sower.enabled
     repository: "file://../sower"
   - name: wts
@@ -160,7 +160,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.100
+version: 0.1.101
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/gen3/README.md
+++ b/helm/gen3/README.md
@@ -1,6 +1,6 @@
 # gen3
 
-![Version: 0.1.100](https://img.shields.io/badge/Version-0.1.100-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.101](https://img.shields.io/badge/Version-0.1.101-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 Helm chart to deploy Gen3 Data Commons
 
@@ -47,7 +47,7 @@ Helm chart to deploy Gen3 Data Commons
 | file://../requestor | requestor | 0.1.21 |
 | file://../revproxy | revproxy | 0.1.33 |
 | file://../sheepdog | sheepdog | 0.1.25 |
-| file://../sower | sower | 0.1.25 |
+| file://../sower | sower | 0.1.26 |
 | file://../ssjdispatcher | ssjdispatcher | 0.1.25 |
 | file://../wts | wts | 0.1.24 |
 | https://charts.bitnami.com/bitnami | postgresql | 11.9.13 |

--- a/helm/sower/Chart.yaml
+++ b/helm/sower/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.25
+version: 0.1.26
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/sower/README.md
+++ b/helm/sower/README.md
@@ -1,6 +1,6 @@
 # sower
 
-![Version: 0.1.25](https://img.shields.io/badge/Version-0.1.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.26](https://img.shields.io/badge/Version-0.1.26-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for gen3 sower
 
@@ -32,11 +32,10 @@ A Helm chart for gen3 sower
 | commonLabels | map | `nil` | Will completely override the commonLabels defined in the common chart's _label_setup.tpl |
 | criticalService | string | `"false"` | Valid options are "true" or "false". If invalid option is set- the value will default to "false". |
 | env | list | `nil` | Environment variables to pass to the container |
-| externalSecrets | map | `{"createK8sPelicanServiceSecret":false,"createK8sSowerJobsSecret":false,"pelicanserviceG3auto":null,"peregrineRawSecret":null,"sowerjobsG3auto":null}` | External Secrets settings. |
+| externalSecrets | map | `{"createK8sPelicanServiceSecret":false,"createK8sSowerJobsSecret":false,"pelicanserviceG3auto":null,"sowerjobsG3auto":null}` | External Secrets settings. |
 | externalSecrets.createK8sPelicanServiceSecret | string | `false` | Will create the Helm "pelicanservice-g3auto" secret even if Secrets Manager is enabled. This is helpful if you are wanting to use External Secrets for some, but not all secrets. |
 | externalSecrets.createK8sSowerJobsSecret | string | `false` | Will create the Helm "sower-jobs-g3auto" secret even if Secrets Manager is enabled. This is helpful if you are wanting to use External Secrets for some, but not all secrets. |
 | externalSecrets.pelicanserviceG3auto | string | `nil` | Will override the name of the aws secrets manager secret. Default is "pelicanservice-g3auto" |
-| externalSecrets.peregrineRawSecret | string | `nil` | The name of an aws secrets manager secret that stores a cloud-automation compliant version of peregrine config, for sower jobs expecting that format. If left blank, will not create |
 | externalSecrets.sowerjobsG3auto | string | `nil` | Will override the name of the aws secrets manager secret. Default is "sower-jobs-g3auto" |
 | fullnameOverride | string | `""` | Override the full name of the deployment. |
 | gen3Namespace | string | `"default"` | Namespace to deploy the job. |

--- a/helm/sower/templates/external-secret.yaml
+++ b/helm/sower/templates/external-secret.yaml
@@ -16,27 +16,6 @@ spec:
     remoteRef:
       #name of secret in secrets manager
       key: {{include "pelicanservice-g3auto" .}}
-      property: config.json
----
-{{- end }}
-{{- if .Values.externalSecrets.peregrineRawSecret }}
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  name: peregrine-creds
-spec:
-  refreshInterval: 5m
-  secretStoreRef:
-    name: {{include "common.SecretStore" .}}
-    kind: SecretStore
-  target:
-    name: peregrine-creds
-    creationPolicy: Owner
-  data:
-  - secretKey: creds.json
-    remoteRef:
-      #TODO make this parameterized
-      key: {{ .Values.externalSecrets.peregrineRawSecret }}
 ---
 {{- end }}
 {{- if and (.Values.global.externalSecrets.deploy) (not .Values.externalSecrets.createK8sSowerJobsSecret) }}

--- a/helm/sower/values.yaml
+++ b/helm/sower/values.yaml
@@ -78,8 +78,6 @@ externalSecrets:
   createK8sSowerJobsSecret: false
   # -- (string) Will override the name of the aws secrets manager secret. Default is "sower-jobs-g3auto"
   sowerjobsG3auto:
-  # -- (string) The name of an aws secrets manager secret that stores a cloud-automation compliant version of peregrine config, for sower jobs expecting that format. If left blank, will not create
-  peregrineRawSecret:
 
 # -- (map) Values for sower secrets and keys for External Secrets.
 secrets:


### PR DESCRIPTION
Sower pulls in peregrine db creds via the deployment.yaml instead of a volume mounted secret, so we don't need an external secret for this. 

Peregrine also already has the external secret resource for "peregrine-dbcreds" here:
[https://github.com/uc-cdis/gen3-helm/blob/master/helm/peregrine/templates/external-secret.yaml#L2](https://github.com/uc-cdis/gen3-helm/blob/master/helm/peregrine/templates/external-secret.yaml#L2)

Please also reference this PR:
[https://github.com/uc-cdis/gen3-helm/pull/169](https://github.com/uc-cdis/gen3-helm/pull/169)