### PR TITLE
Add PDB Budgets for Local ES/Postgres

### DIFF
--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -165,7 +165,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.2.33
+version: 0.2.34
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/gen3/README.md
+++ b/helm/gen3/README.md
@@ -1,6 +1,6 @@
 # gen3
 
-![Version: 0.2.33](https://img.shields.io/badge/Version-0.2.33-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.2.34](https://img.shields.io/badge/Version-0.2.34-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 Helm chart to deploy Gen3 Data Commons
 
@@ -151,6 +151,7 @@ Helm chart to deploy Gen3 Data Commons
 | global.netPolicy | bool | `{"dbSubnet":"","enabled":false}` | Global flags to control and manage network policies for a Gen3 installation NOTE: Network policies are currently a beta feature. Use with caution! |
 | global.netPolicy.dbSubnet | array | `""` | A CIDR range representing a database subnet, that services with a database need access to |
 | global.netPolicy.enabled | bool | `false` | Whether network policies are enabled |
+| global.pdb | bool | `false` | If the service will be deployed with a Pod Disruption Budget. Note- you need to have more than 2 replicas for the pdb to be deployed. |
 | global.portalApp | string | `"gitops"` | Portal application name. |
 | global.postgres.dbCreate | bool | `true` | Whether the database create job should run. |
 | global.postgres.externalSecret | string | `""` | Name of external secret of the postgres master credentials. Disabled if empty |

--- a/helm/gen3/templates/postgres-es-pdb.yaml
+++ b/helm/gen3/templates/postgres-es-pdb.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.global.pdb (.Values.global.dev) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: postgres-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+       app.kubernetes.io/name: "postgresql"
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: elasticsearch-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: "gen3-elasticsearch-master"
+{{- end }}

--- a/helm/gen3/values.yaml
+++ b/helm/gen3/values.yaml
@@ -108,6 +108,8 @@ global:
     dbSubnet: ""
   # -- (int) Number of dispatcher jobs.
   dispatcherJobNum: "10"
+  # -- (bool) If the service will be deployed with a Pod Disruption Budget. Note- you need to have more than 2 replicas for the pdb to be deployed.
+  pdb: false
   # -- (map) If you would like to add any extra values to the manifest-global configmap.
   manifestGlobalExtraValues: {}
   # -- (string) Which app will be served on /. Needs be set to portal for portal, or "gen3ff" for frontendframework.


### PR DESCRIPTION
Updating gen3 chart to create a pdb for postgres and elasticsearch if it is enabled globally, so they are disrupted less.

