### PR TITLE
Update tempo endpoint in alloy config.

### DIFF
--- a/helm/cluster-level-resources/values.yaml
+++ b/helm/cluster-level-resources/values.yaml
@@ -242,7 +242,7 @@ alloy-configmap-data: |
 
   otelcol.exporter.otlp "tempo" {
     client {
-      endpoint = "http://monitoring-tempo-distributor.monitoring:4317"
+      endpoint = "http://tempo.planx-pla.net:4317"
       // Configure TLS settings for communicating with the endpoint.
       tls {
           // The connection is insecure.


### PR DESCRIPTION
We are testing opentelemetry in our Metadata service, so I needed to add a tempo endpoint in the allure config to send to the new tempo data source.