### PR TITLE
Fixing HPA for Presigned URL Fence

### DIFF
--- a/helm/fence/Chart.yaml
+++ b/helm/fence/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.61
+version: 0.1.62
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/fence/README.md
+++ b/helm/fence/README.md
@@ -1,6 +1,6 @@
 # fence
 
-![Version: 0.1.61](https://img.shields.io/badge/Version-0.1.61-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.62](https://img.shields.io/badge/Version-0.1.62-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for gen3 Fence
 

--- a/helm/fence/templates/presigned-url-fence-hpa.yaml
+++ b/helm/fence/templates/presigned-url-fence-hpa.yaml
@@ -1,3 +1,4 @@
+{{- if default .Values.global.autoscaling.enabled .Values.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -8,7 +9,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{.Chart.Name}}-deployment
+    name: presigned-url-fence-deployment
   minReplicas: {{ default .Values.global.autoscaling.minReplicas .Values.autoscaling.minReplicas }}
   maxReplicas: {{ default .Values.global.autoscaling.maxReplicas .Values.autoscaling.maxReplicas }}
   metrics:
@@ -28,3 +29,4 @@ spec:
         type: AverageValue
         averageValue: {{ default .Values.global.autoscaling.averageMemoryValue .Values.autoscaling.averageMemoryValue }}
     {{- end }}
+{{- end }}

--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -56,7 +56,7 @@ dependencies:
     repository: "file://../frontend-framework"
     condition: frontend-framework.enabled
   - name: fence
-    version: 0.1.61
+    version: 0.1.62
     repository: "file://../fence"
     condition: fence.enabled
   - name: gen3-user-data-library
@@ -169,7 +169,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.2.72
+version: 0.2.73
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/gen3/README.md
+++ b/helm/gen3/README.md
@@ -1,6 +1,6 @@
 # gen3
 
-![Version: 0.2.72](https://img.shields.io/badge/Version-0.2.72-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.2.73](https://img.shields.io/badge/Version-0.2.73-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 Helm chart to deploy Gen3 Data Commons
 
@@ -31,7 +31,7 @@ Helm chart to deploy Gen3 Data Commons
 | file://../datareplicate | datareplicate | 0.0.33 |
 | file://../dicom-server | dicom-server | 0.1.20 |
 | file://../etl | etl | 0.1.16 |
-| file://../fence | fence | 0.1.61 |
+| file://../fence | fence | 0.1.62 |
 | file://../frontend-framework | frontend-framework | 0.1.14 |
 | file://../gen3-analysis | gen3-analysis | 0.1.2 |
 | file://../gen3-network-policies | gen3-network-policies | 0.1.2 |


### PR DESCRIPTION
### Bug Fixes
Updating hpa to target presigned-url to actually target the right deployment.
Updating presigned HPA URL to only be added if autoscaling is enabled.
