### PR TITLE
datareplicate: use .Release.Namespace as fallback when job namespace is undefined

### DIFF
--- a/helm/datareplicate/Chart.yaml
+++ b/helm/datareplicate/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/datareplicate/README.md
+++ b/helm/datareplicate/README.md
@@ -1,6 +1,6 @@
 # datareplicate
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for gen3 datareplicate
 

--- a/helm/datareplicate/templates/aws-batch-replication-job.yaml
+++ b/helm/datareplicate/templates/aws-batch-replication-job.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: aws-batch-replicate
-  namespace: {{ .Values.awsBatchReplicateJob.namespace }}
+  namespace: {{ default .Release.Namespace .Values.awsBatchReplicateJob.namespace }}
 spec:
   schedule: {{ .Values.awsBatchReplicateJob.schedule | quote }}
   suspend: {{ .Values.suspendCronjob }}

--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -44,7 +44,7 @@ dependencies:
     repository: file://../dashboard
     condition: dashboard.enabled
   - name: datareplicate
-    version: 0.1.5
+    version: 0.1.6
     repository: "file://../datareplicate"
     condition: datareplicate.enabled
   - name: etl
@@ -173,7 +173,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.2.101
+version: 0.2.102
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/gen3/README.md
+++ b/helm/gen3/README.md
@@ -1,6 +1,6 @@
 # gen3
 
-![Version: 0.2.101](https://img.shields.io/badge/Version-0.2.101-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.2.102](https://img.shields.io/badge/Version-0.2.102-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 Helm chart to deploy Gen3 Data Commons
 
@@ -28,7 +28,7 @@ Helm chart to deploy Gen3 Data Commons
 | file://../cohort-middleware | cohort-middleware | 0.1.16 |
 | file://../common | common | 0.1.28 |
 | file://../dashboard | dashboard | 0.1.13 |
-| file://../datareplicate | datareplicate | 0.1.5 |
+| file://../datareplicate | datareplicate | 0.1.6 |
 | file://../dicom-server | dicom-server | 0.1.23 |
 | file://../etl | etl | 0.1.19 |
 | file://../fence | fence | 0.1.65 |


### PR DESCRIPTION
datareplicate: use .Release.Namespace as fallback when job namespace is undefined
