### PR TITLE
fix: Remove worker-templates-volume from Funnel values.yaml

### DIFF
--- a/helm/funnel/values.yaml
+++ b/helm/funnel/values.yaml
@@ -246,10 +246,6 @@ funnel:
         - key: client_secret
           path: client_secret
 
-  - name: worker-templates-volume
-    configMap:
-      name: funnel-worker-templates
-
   - name: plugin-volume
     emptyDir: {}  # Shared volume
 
@@ -264,9 +260,6 @@ funnel:
     - name: "funnel-oidc-volume"
       readOnly: true
       mountPath: "/etc/config/oidc"
-
-    - name: worker-templates-volume
-      mountPath: /etc/funnel/templates
 
     - name: plugin-volume
       mountPath: /opt/funnel/plugin-binaries


### PR DESCRIPTION
# Overview

This PR updates Funnel's `values.yaml` with that of the upstream Helm Chart ([**v0.1.99-rc.26**](https://github.com/ohsu-comp-bio/helm-charts/blob/funnel-0.1.99-rc.26/charts/funnel/values.yaml#L549-L567))!

This addresses (and hopefully fixes!) the following error when deploying Funnel:

```sh
MountVolume.SetUp failed for volume "worker-templates-volume" : configmap "funnel-worker-templates" not found
```

> [!IMPORTANT]
>
> Open Question: What specific Funnel release caused this breaking change?
