### PR TITLE
Add single table indexd migration job

### DIFF
--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -92,7 +92,7 @@ dependencies:
     repository: "file://../hatchery"
     condition: hatchery.enabled
   - name: indexd
-    version: 0.1.43
+    version: 0.1.44
     repository: "file://../indexd"
     condition: indexd.enabled
   - name: manifestservice
@@ -197,7 +197,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.3.36
+version: 0.3.37
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/indexd/Chart.yaml
+++ b/helm/indexd/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.43
+version: 0.1.44
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/indexd/README.md
+++ b/helm/indexd/README.md
@@ -1,6 +1,6 @@
 # indexd
 
-![Version: 0.1.43](https://img.shields.io/badge/Version-0.1.43-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.44](https://img.shields.io/badge/Version-0.1.44-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for gen3 indexd
 
@@ -72,6 +72,7 @@ A Helm chart for gen3 indexd
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Docker image pull secrets. |
 | metricsEnabled | bool | `false` | Whether Metrics are enabled. indexd doesn't expose metrics yet. |
+| migrateToSingleTable.args | string | `nil` |  |
 | nameOverride | string | `""` | Override the name of the chart. |
 | netPolicy | map | `{"egressApps":["fence","presigned-url-fence","fenceshib","peregrine","sheepdog","ssjdispatcherjob","metadata","mariner","mariner-engine"],"ingressApps":["fence","presigned-url-fence","fenceshib","peregrine","sheepdog","ssjdispatcherjob","metadata","mariner","mariner-engine"]}` | Configuration for network policies created by this chart. Only relevant if "global.netPolicy.enabled" is set to true |
 | netPolicy.egressApps | array | `["fence","presigned-url-fence","fenceshib","peregrine","sheepdog","ssjdispatcherjob","metadata","mariner","mariner-engine"]` | List of apps that this app requires egress to |

--- a/helm/indexd/templates/migrate-to-single-table.yaml
+++ b/helm/indexd/templates/migrate-to-single-table.yaml
@@ -1,0 +1,81 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: migrate-to-single-table-indexd
+spec:
+  # Invalid schedule, feb 31st - we never want this to actually trigger itself.
+  schedule: 0 0 31 2 *
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: gen3job
+        spec:
+          restartPolicy: Never
+          automountServiceAccountToken: false
+          {{- with .Values.volumes }}
+          volumes:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          containers:
+            - name: indexd
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command:
+                - /bin/sh
+                - -c
+                - |
+                    python - <<'PY'
+                    import json, os
+
+                    with open("/indexd/bin/creds.json", "w") as f:
+                        json.dump({
+                            "db_host": os.environ["PGHOST"],
+                            "db_username": os.environ["PGUSER"],
+                            "db_password": os.environ["PGPASSWORD"],
+                            "db_database": os.environ["PGDB"],
+                        }, f, indent=2)
+                    PY
+                    python /indexd/bin/migrate_to_single_table.py --creds-file /indexd/bin/creds.json {{.Values.migrateToSingleTable.args}}
+              env:
+                - name: PGHOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: indexd-dbcreds
+                      key: host
+                      optional: false
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      name: indexd-dbcreds
+                      key: username
+                      optional: false
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: indexd-dbcreds
+                      key: password
+                      optional: false
+                - name: PGDB
+                  valueFrom:
+                    secretKeyRef:
+                      name: indexd-dbcreds
+                      key: database
+                      optional: false
+                - name: DBREADY
+                  valueFrom:
+                    secretKeyRef:
+                      name: indexd-dbcreds
+                      key: dbcreated
+                      optional: false
+                - name: DEFAULT_PREFIX
+                  value: {{ .Values.defaultPrefix }}
+                - name: USE_SINGLE_TABLE
+                  value: {{ .Values.useSingleTable | quote }}
+                {{- toYaml .Values.env | nindent 16  }}

--- a/helm/indexd/values.yaml
+++ b/helm/indexd/values.yaml
@@ -284,7 +284,9 @@ uwsgi:
 # -- (string) default prefix for indexd - must end in slash
 defaultPrefix: "PREFIX/"
 useSingleTable: "False"
-
+migrateToSingleTable:
+  # -- (string) non-credential args for the migrate-to-single-table indexd job. Example: --start-did dg.4503/04de0c66-150b-4b8c-8043-c5ed7bbf04a4
+  args:
 # Values to determine the labels that are used for the deployment, pod, etc.
 # -- (string) Valid options are "production" or "dev". If invalid option is set- the value will default to "dev".
 release: "production"


### PR DESCRIPTION

Link to JIRA ticket if there is one:

### New Features
- Adds single table indexd migration job, runnable with `k create job <job name> --from=cronjob/migrate-to-single-table-indexd` with support for resumable migrations through the setting the jobs arguments via `indexd.migrateToSingleTable.args`. See https://github.com/uc-cdis/indexd/blob/master/bin/migrate_to_single_table.py#L2 for more details.
### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
