### PR TITLE
revproxy nginx client_max_body_size 5G

### DIFF
--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -116,7 +116,7 @@ dependencies:
     repository: "file://../requestor"
     condition: requestor.enabled
   - name: revproxy
-    version: 0.1.57
+    version: 0.1.58
     repository: "file://../revproxy"
     condition: revproxy.enabled
   - name: sheepdog
@@ -197,7 +197,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.3.42
+version: 0.3.43
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/gen3/README.md
+++ b/helm/gen3/README.md
@@ -1,6 +1,6 @@
 # gen3
 
-![Version: 0.3.42](https://img.shields.io/badge/Version-0.3.42-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.3.43](https://img.shields.io/badge/Version-0.3.43-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 Helm chart to deploy Gen3 Data Commons
 
@@ -54,7 +54,7 @@ Helm chart to deploy Gen3 Data Commons
 | file://../peregrine | peregrine | 0.1.41 |
 | file://../portal | portal | 0.1.57 |
 | file://../requestor | requestor | 0.1.33 |
-| file://../revproxy | revproxy | 0.1.57 |
+| file://../revproxy | revproxy | 0.1.58 |
 | file://../sheepdog | sheepdog | 0.1.41 |
 | file://../sower | sower | 0.1.44 |
 | file://../ssjdispatcher | ssjdispatcher | 0.1.44 |

--- a/helm/revproxy/Chart.yaml
+++ b/helm/revproxy/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.57
+version: 0.1.58
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/revproxy/README.md
+++ b/helm/revproxy/README.md
@@ -1,6 +1,6 @@
 # revproxy
 
-![Version: 0.1.57](https://img.shields.io/badge/Version-0.1.57-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.58](https://img.shields.io/badge/Version-0.1.58-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for gen3 revproxy
 

--- a/helm/revproxy/nginx/nginx.conf
+++ b/helm/revproxy/nginx/nginx.conf
@@ -299,7 +299,7 @@ map $http_user_agent $loggable {
 
     #
     # Accomodate large request bodies (override the default of 1MB)
-    client_max_body_size  5Gi;
+    client_max_body_size  5g;
 
     #
     # CSRF check

--- a/helm/revproxy/nginx/nginx.conf
+++ b/helm/revproxy/nginx/nginx.conf
@@ -298,6 +298,10 @@ map $http_user_agent $loggable {
     client_header_buffer_size 8k;
 
     #
+    # Accomodate large request bodies (override the default of 1MB)
+    client_max_body_size  5Gi;
+
+    #
     # CSRF check
     # This block requires a csrftoken for all POST requests.
     #


### PR DESCRIPTION
[Slack thread](https://cdis.slack.com/archives/C0552E6EAM7/p1778170316569959)
When making multipart upload requests to gen3-workflow's S3 endpoint:
```
An error occurred (413) when calling the UploadPart operation: Content Too Large
```
Revproxy's nginx has no explicit `client_max_body_size`, so it defaults to 1MB, which is too small for S3 multipart upload parts.

### New Features

### Breaking Changes

### Bug Fixes

### Improvements
- Set revproxy's `nginx client_max_body_size` to 5G to accomodate request bodies larger than 1MB

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
