### PR TITLE
cilium: add k8sServiceHost fallback for clusters missing cluster-info CM

### DIFF
--- a/helm/cluster-level-resources/Chart.yaml
+++ b/helm/cluster-level-resources/Chart.yaml
@@ -4,6 +4,6 @@ description: An app-of-apps Helm chart that allows for flexible deployment of re
 
 type: application
 
-version: 0.6.42
+version: 0.6.43
 
 appVersion: "1.17.0"

--- a/helm/cluster-level-resources/README.md
+++ b/helm/cluster-level-resources/README.md
@@ -1,6 +1,6 @@
 # cluster-level-resources
 
-![Version: 0.6.42](https://img.shields.io/badge/Version-0.6.42-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.17.0](https://img.shields.io/badge/AppVersion-1.17.0-informational?style=flat-square)
+![Version: 0.6.43](https://img.shields.io/badge/Version-0.6.43-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.17.0](https://img.shields.io/badge/AppVersion-1.17.0-informational?style=flat-square)
 
 An app-of-apps Helm chart that allows for flexible deployment of resources that support Gen3
 
@@ -35,6 +35,7 @@ An app-of-apps Helm chart that allows for flexible deployment of resources that 
 | cert-manager.targetRevision | string | `"v1.17.2"` |  |
 | cilium.configuration.enabled | bool | `false` |  |
 | cilium.enabled | bool | `false` |  |
+| cilium.k8sServiceHost | string | `""` |  |
 | cilium.targetRevision | string | `"1.18.4"` |  |
 | cluster | string | `"unfunded"` |  |
 | configuration.configurationRepo | string | `"https://github.com/uc-cdis/gen3-gitops"` |  |

--- a/helm/cluster-level-resources/templates/cilium.yaml
+++ b/helm/cluster-level-resources/templates/cilium.yaml
@@ -56,9 +56,13 @@ spec:
               enabled: true
           ipam:
             mode: cluster-pool
+          {{- if index .Values "cilium" "k8sServiceHost" }}
+          k8sServiceHost: {{ index .Values "cilium" "k8sServiceHost" | quote }}
+          {{- else }}
           k8sServiceHostRef:
             key: hostname
             name: cluster-info
+          {{- end }}
           k8sServiceLookupConfigMapName: kube-system
           k8sServicePort: 443
           kubeProxyReplacement: true

--- a/helm/cluster-level-resources/values.yaml
+++ b/helm/cluster-level-resources/values.yaml
@@ -81,6 +81,7 @@ argo-workflows:
 cilium:
   enabled: false
   targetRevision: "1.18.4"
+  k8sServiceHost: ""  # set to override k8sServiceHostRef
   configuration:
     enabled: false
 


### PR DESCRIPTION
cluster-info ConfigMap is missing on some EKS clusters, which breaks k8sServiceHostRef lookup, causing CreateContainerConfigError on Cilium pod startup.
Added k8sServiceHost to the values file. When set to the Kubernetes API server hostname, Cilium skips the cluster-info ConfigMap lookup entirely. Clusters that already have cluster-info ConfigMap do not require any changes.

Link to JIRA ticket if there is one:

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
