### PR TITLE
Bump up cluster_level_resources to prevent release-chart-helper GH action

### DIFF
--- a/helm/cluster-level-resources/Chart.yaml
+++ b/helm/cluster-level-resources/Chart.yaml
@@ -4,6 +4,6 @@ description: An app-of-apps Helm chart that allows for flexible deployment of re
 
 type: application
 
-version: 0.6.42
+version: 0.6.43
 
 appVersion: "1.17.0"

--- a/helm/cluster-level-resources/README.md
+++ b/helm/cluster-level-resources/README.md
@@ -1,6 +1,6 @@
 # cluster-level-resources
 
-![Version: 0.6.42](https://img.shields.io/badge/Version-0.6.42-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.17.0](https://img.shields.io/badge/AppVersion-1.17.0-informational?style=flat-square)
+![Version: 0.6.43](https://img.shields.io/badge/Version-0.6.43-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.17.0](https://img.shields.io/badge/AppVersion-1.17.0-informational?style=flat-square)
 
 An app-of-apps Helm chart that allows for flexible deployment of resources that support Gen3
 


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

* This [commit](https://github.com/uc-cdis/gen3-helm/commit/acad3d6a4674c432ebe8af90b8c5d7816b68c463) has missed updating cluster level resources chart version causing release-helper GH action to break ([here](https://github.com/uc-cdis/gen3-helm/actions/runs/25766385741/job/75707807679)). 

Link to JIRA ticket if there is one:

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
