### PR TITLE
fix: parameterize hardcoded AWS us-east-1 region in Helm templates

### DIFF
--- a/helm/access-backend/templates/deployment.yaml
+++ b/helm/access-backend/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
           - name: GEN3_DEBUG
             value: "False"
           - name: AWS_DEFAULT_REGION
-            value: "us-east-1"
+            value: {{ .Values.global.aws.region | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         livenessProbe:
           httpGet:

--- a/helm/access-backend/values.yaml
+++ b/helm/access-backend/values.yaml
@@ -8,6 +8,8 @@ global:
   aws:
     # -- (bool) Set to true if deploying to AWS. Controls ingress annotations.
     enabled: false
+    # -- (string) AWS region for this deployment
+    region: us-east-1
     # -- (string) Credentials for AWS stuff.
     awsAccessKeyId:
     # -- (string) Credentials for AWS stuff.

--- a/helm/aws-es-proxy/templates/crossplane.yaml
+++ b/helm/aws-es-proxy/templates/crossplane.yaml
@@ -46,8 +46,8 @@ spec:
             "Effect":"Allow",
             "Action": "es:*",
             "Resource":[
-                "arn:aws:es:us-east-1:{{ .Values.global.crossplane.accountId }}:domain/{{ include "aws-es-proxy.esEndpointName" . }}",
-                "arn:aws:es:us-east-1:{{ .Values.global.crossplane.accountId }}:domain/{{ include "aws-es-proxy.esEndpointName" . }}/*"
+                "arn:aws:es:{{ .Values.awsRegion }}:{{ .Values.global.crossplane.accountId }}:domain/{{ include "aws-es-proxy.esEndpointName" . }}",
+                "arn:aws:es:{{ .Values.awsRegion }}:{{ .Values.global.crossplane.accountId }}:domain/{{ include "aws-es-proxy.esEndpointName" . }}/*"
             ]
           }
         ]

--- a/helm/aws-es-proxy/values.yaml
+++ b/helm/aws-es-proxy/values.yaml
@@ -113,6 +113,8 @@ ports:
 
 # -- (str) Elasticsearch endpoint in AWS
 esEndpoint: test.us-east-1.es.amazonaws.com
+# -- (str) AWS region for the Elasticsearch domain, used for Crossplane IAM policy ARNs
+awsRegion: us-east-1
 
 # -- (list) Volumes to mount to the pod.
 volumeMounts:

--- a/helm/aws-sigv4-proxy/templates/crossplane.yaml
+++ b/helm/aws-sigv4-proxy/templates/crossplane.yaml
@@ -46,8 +46,8 @@ spec:
             "Effect":"Allow",
             "Action": "es:*",
             "Resource":[
-                "arn:aws:es:us-east-1:{{ .Values.global.crossplane.accountId }}:domain/{{ include "aws-sigv4-proxy.esEndpointName" . }}",
-                "arn:aws:es:us-east-1:{{ .Values.global.crossplane.accountId }}:domain/{{ include "aws-sigv4-proxy.esEndpointName" . }}/*"
+                "arn:aws:es:{{ .Values.awsRegion }}:{{ .Values.global.crossplane.accountId }}:domain/{{ include "aws-sigv4-proxy.esEndpointName" . }}",
+                "arn:aws:es:{{ .Values.awsRegion }}:{{ .Values.global.crossplane.accountId }}:domain/{{ include "aws-sigv4-proxy.esEndpointName" . }}/*"
             ]
           }
         ]

--- a/helm/cluster-level-resources/templates/fluentd.yaml
+++ b/helm/cluster-level-resources/templates/fluentd.yaml
@@ -28,7 +28,7 @@ spec:
             - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
               value: "cri"
             - name: AWS_REGION
-              value: "us-east-1"
+              value: {{ .Values.fluentd.awsRegion | quote }}
           image:
             tag: v1.15.3-debian-cloudwatch-1.0
       {{- end }}

--- a/helm/cluster-level-resources/templates/grafana-alloy.yaml
+++ b/helm/cluster-level-resources/templates/grafana-alloy.yaml
@@ -31,7 +31,7 @@ spec:
                     - key: topology.kubernetes.io/zone
                       operator: In
                       values:
-                      - us-east-1a
+                      - {{ index .Values "grafana-alloy" "availabilityZone" }}
 
           alloy:
             stabilityLevel: "public-preview"

--- a/helm/cluster-level-resources/templates/karpenter.yaml
+++ b/helm/cluster-level-resources/templates/karpenter.yaml
@@ -99,7 +99,7 @@ spec:
               digest: {{ .Values.karpenter.controller.image.digest }}
             env:
               - name: AWS_REGION
-                value: us-east-1
+                value: {{ .Values.karpenter.awsRegion }}
             resources:
               requests:
                 memory: {{ .Values.karpenter.resources.requests.memory }}

--- a/helm/cluster-level-resources/values.yaml
+++ b/helm/cluster-level-resources/values.yaml
@@ -102,12 +102,16 @@ external-secrets:
 fluentd:
   enabled: false
   targetRevision: "0.5.2"
+  # -- (string) AWS region for fluentd CloudWatch logging
+  awsRegion: "us-east-1"
   configuration:
     enabled: false
 
 grafana-alloy:
   enabled: false
   targetRevision: 0.4.0
+  # -- (string) The availability zone to pin the grafana-alloy controller to.
+  availabilityZone: "us-east-1a"
   configuration:
     enabled: false
 

--- a/helm/dashboard/templates/deployment.yaml
+++ b/helm/dashboard/templates/deployment.yaml
@@ -202,7 +202,7 @@ spec:
             main "$@"
         env:
         - name: AWS_DEFAULT_REGION
-          value: "us-east-1"
+          value: {{ .Values.global.aws.region | quote }}
         - name: REPO_URL
           value: {{ .Values.dashboardConfig.gitopsRepo }}
         volumeMounts:

--- a/helm/dashboard/values.yaml
+++ b/helm/dashboard/values.yaml
@@ -27,6 +27,8 @@ global:
       versioningEnabled: false
   aws:
     enabled: false
+    # -- (string) AWS region for this deployment
+    region: us-east-1
   # -- (map) Karpenter topology spread configuration.
   topologySpread:
     # -- (bool) Whether to enable topology spread constraints for all subcharts that support it.

--- a/helm/datareplicate/templates/aws-bucket-replicate-job.yaml
+++ b/helm/datareplicate/templates/aws-bucket-replicate-job.yaml
@@ -81,7 +81,7 @@ spec:
                 cat /secrets/dcf_dataservice_settings.py > ./dcfdataservice/settings.py
                 echo """
                 [default]
-                region: us-east-1
+                region: {{ .Values.global.aws.region }}
                 """ > ~/.aws/config
                 aws configure set default.s3.max_concurrent_requests 1000
                 aws configure set default.s3.max_queue_size 10000

--- a/helm/datareplicate/templates/remove-objects-from-clouds-job.yaml
+++ b/helm/datareplicate/templates/remove-objects-from-clouds-job.yaml
@@ -80,7 +80,7 @@ spec:
                 cat /secrets/dcf_dataservice_settings.py > ./dcfdataservice/settings.py
                 echo """
                 [default]
-                region: us-east-1
+                region: {{ .Values.global.aws.region }}
                 """ > ~/.aws/config
                 gcloud auth activate-service-account --key-file=/secrets/google_service_account_creds
                 export GOOGLE_APPLICATION_CREDENTIALS=/secrets/google_service_account_creds

--- a/helm/datareplicate/templates/replicate-validation-job.yaml
+++ b/helm/datareplicate/templates/replicate-validation-job.yaml
@@ -84,7 +84,7 @@ spec:
               - |
                 echo """
                 [default]
-                region: us-east-1
+                region: {{ .Values.global.aws.region }}
                 """ > ~/.aws/config
                 cat /secrets/dcf_dataservice_settings.py > ./dcfdataservice/settings.py
                 gcloud auth activate-service-account --key-file=/secrets/google_service_account_creds

--- a/helm/datareplicate/values.yaml
+++ b/helm/datareplicate/values.yaml
@@ -6,6 +6,10 @@ suspendCronjob: true
 
 # Global configuration
 global:
+  # -- (map) AWS configuration
+  aws:
+    # -- (string) AWS region for this deployment
+    region: us-east-1
   # -- (map) External Secrets settings.
   externalSecrets:
     # -- (bool) Will use ExternalSecret resources to pull secrets from Secrets Manager instead of creating them locally. Be cautious as this will override secrets you have deployed.

--- a/helm/funnel/templates/funnel-oidc.yaml
+++ b/helm/funnel/templates/funnel-oidc.yaml
@@ -192,7 +192,7 @@ spec:
                   echo " /!\  Ensure the external secret '$FUNNEL_REMOTE_SECRET_NAME' is deleted in AWS Secrets Manager before running this job."
                   echo "   Otherwise, the External Secrets Operator may overwrite this new secret."
                   echo "   To delete it manually, run:"
-                  echo "   aws secretsmanager delete-secret --secret-id \"$FUNNEL_REMOTE_SECRET_NAME\" --region us-east-1 --force-delete-without-recovery"
+                  echo "   aws secretsmanager delete-secret --secret-id \"$FUNNEL_REMOTE_SECRET_NAME\" --region {{ .Values.global.aws.region }} --force-delete-without-recovery"
                   exit 1
                 fi
               fi

--- a/helm/gen3/templates/_aurora_rds_copy_job.tpl
+++ b/helm/gen3/templates/_aurora_rds_copy_job.tpl
@@ -62,7 +62,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: aurora-db-copy-container
-              image: {{ .Values.auroraRdsCopyJob.image }}
+              image: {{ $.Values.auroraRdsCopyJob.image }}
               command:
                 - /bin/bash
                 - -c

--- a/helm/gen3/templates/_aurora_rds_copy_job.tpl
+++ b/helm/gen3/templates/_aurora_rds_copy_job.tpl
@@ -62,7 +62,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: aurora-db-copy-container
-              image: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:master
+              image: {{ .Values.auroraRdsCopyJob.image }}
               command:
                 - /bin/bash
                 - -c

--- a/helm/gen3/values.yaml
+++ b/helm/gen3/values.yaml
@@ -501,3 +501,5 @@ auroraRdsCopyJob:
   writeToK8sSecret: false
   writeToAwsSecret: false
   services: []
+  # -- (string) Docker image for the aurora DB copy job. Override to use a different registry or region.
+  image: "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:master"

--- a/wip/terraform-runner-job/templates/credentials.yaml
+++ b/wip/terraform-runner-job/templates/credentials.yaml
@@ -11,4 +11,4 @@ stringData:
     {{- if .Values.credentials.aws.session_token }}
     aws_session_token={{ .Values.credentials.aws.session_token }}
     {{- end }}
-    region=us-east-1
+    region={{ .Values.credentials.aws.region }}

--- a/wip/terraform-runner-job/values.yaml
+++ b/wip/terraform-runner-job/values.yaml
@@ -10,6 +10,8 @@ credentials:
     key: ""
     secret: ""
     session_token: ""
+    # -- (string) AWS region for this deployment
+    region: "us-east-1"
 
 terraform:
   resource_name: ""


### PR DESCRIPTION
## Summary

Replaces all hardcoded `us-east-1` strings in Helm **template** files with references to configurable values. This makes it possible to deploy Gen3 in any AWS region without manual template edits.

All new values default to `us-east-1` to preserve existing behaviour for anyone who doesn't set them explicitly.

## Changes

| Chart | Template fixed | Value added / used |
|---|---|---|
| `access-backend` | `AWS_DEFAULT_REGION` env var | `global.aws.region` (new) |
| `aws-es-proxy` | Crossplane IAM policy ARNs | `awsRegion` (new) |
| `aws-sigv4-proxy` | Crossplane IAM policy ARNs | `awsRegion` (existing) |
| `cluster-level-resources` | fluentd `AWS_REGION` env var | `fluentd.awsRegion` (new) |
| `cluster-level-resources` | grafana-alloy node affinity AZ | `grafana-alloy.availabilityZone` (new) |
| `cluster-level-resources` | karpenter `AWS_REGION` env var | `karpenter.awsRegion` (existing) |
| `dashboard` | `AWS_DEFAULT_REGION` env var | `global.aws.region` (new) |
| `datareplicate` | `~/.aws/config` region (3 jobs) | `global.aws.region` (new) |
| `funnel` | Region in error-message echo | `global.aws.region` (existing) |
| `gen3` | Aurora copy job ECR image URL | `auroraRdsCopyJob.image` (new) |
| `wip/terraform-runner-job` | AWS credentials file region | `credentials.aws.region` (new) |

## What was NOT changed

- Default values in `values.yaml` remain `us-east-1` — no breaking changes
- Placeholder ARN/OIDC example strings in `values.yaml` (e.g. `arn:aws:acm:us-east-1:123456:certificate`) — these are obviously example strings users replace entirely
- OIDC provider URL examples — same reasoning
- `observability` and `hatchery` AZ lists — these are user-configured example lists, not functional defaults

## How to deploy to a different region

Set `global.aws.region` (and chart-specific values where applicable) in your values override:

```yaml
global:
  aws:
    region: us-west-2

# cluster-level-resources specific:
karpenter:
  awsRegion: "us-west-2"
fluentd:
  awsRegion: "us-west-2"
grafana-alloy:
  availabilityZone: "us-west-2a"

# aws-es-proxy / aws-sigv4-proxy:
awsRegion: "us-west-2"

# wip/terraform-runner-job:
credentials:
  aws:
    region: "us-west-2"
```