### PR TITLE
Feat/gpe 2406 pgvectordefault

### DIFF
--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -197,7 +197,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.3.52
+version: 0.3.53
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/gen3/README.md
+++ b/helm/gen3/README.md
@@ -1,6 +1,6 @@
 # gen3
 
-![Version: 0.3.52](https://img.shields.io/badge/Version-0.3.52-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.3.53](https://img.shields.io/badge/Version-0.3.53-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 Helm chart to deploy Gen3 Data Commons
 
@@ -250,8 +250,7 @@ Helm chart to deploy Gen3 Data Commons
 | peregrine.enabled | bool | `true` | Whether to deploy the peregrine subchart. |
 | pidgin.enabled | bool | `false` | Whether to deploy the pidgin subchart. |
 | portal.enabled | bool | `true` | Whether to deploy the portal subchart. |
-| postgresql | map | `{"image":{"repository":"bitnamilegacy/postgresql","tag":"16.6.0-debian-12-r2"},"primary":{"persistence":{"enabled":false}}}` | To configure postgresql subchart Disable persistence by default so we can spin up and down ephemeral environments |
-| postgresql.primary.persistence.enabled | bool | `false` | Option to persist the dbs data. |
+| postgresql | map | `{"image":{"debug":true,"repository":"pgvector/pgvector","tag":"pg16"},"primary":{"persistence":{"enabled":true,"mountPath":"/bitnami/postgres"}},"volumePermissions":{"enabled":true,"image":{"registry":"bitnamilegacy","repository":"bitnami-shell-archived"}}}` | To configure postgresql subchart Disable persistence by default so we can spin up and down ephemeral environments |
 | requestor.enabled | bool | `false` | Whether to deploy the requestor subchart. |
 | revproxy.enabled | bool | `true` | Whether to deploy the revproxy subchart. |
 | revproxy.ingress.annotations | map | `{}` | Annotations to add to the ingress. |

--- a/helm/gen3/README.md
+++ b/helm/gen3/README.md
@@ -250,7 +250,8 @@ Helm chart to deploy Gen3 Data Commons
 | peregrine.enabled | bool | `true` | Whether to deploy the peregrine subchart. |
 | pidgin.enabled | bool | `false` | Whether to deploy the pidgin subchart. |
 | portal.enabled | bool | `true` | Whether to deploy the portal subchart. |
-| postgresql | map | `{"image":{"debug":true,"repository":"pgvector/pgvector","tag":"pg16"},"primary":{"persistence":{"enabled":true,"mountPath":"/bitnami/postgres"}},"volumePermissions":{"enabled":true,"image":{"registry":"bitnamilegacy","repository":"bitnami-shell-archived"}}}` | To configure postgresql subchart Disable persistence by default so we can spin up and down ephemeral environments |
+| postgresql | map | `{"image":{"repository":"pgvector/pgvector","tag":"pg16"},"primary":{"persistence":{"enabled":true,"mountPath":"/bitnami/postgresql"}},"volumePermissions":{"enabled":true,"image":{"registry":"bitnamilegacy","repository":"bitnami-shell-archived"}}}` | To configure postgresql subchart |
+| postgresql.primary.persistence.enabled | bool | `true` | Whether to enable persistence, required to play nice with pgvector container. |
 | requestor.enabled | bool | `false` | Whether to deploy the requestor subchart. |
 | revproxy.enabled | bool | `true` | Whether to deploy the revproxy subchart. |
 | revproxy.ingress.annotations | map | `{}` | Annotations to add to the ingress. |

--- a/helm/gen3/values.yaml
+++ b/helm/gen3/values.yaml
@@ -415,12 +415,10 @@ access-backend:
   enabled: false
 
 # -- (map) To configure postgresql subchart
-# Disable persistence by default so we can spin up and down ephemeral environments
 postgresql:
   image:
     repository: pgvector/pgvector
     tag: pg16
-    debug: true # FIXME11-debian-11-r45
   volumePermissions:
     enabled: true
     image:
@@ -428,8 +426,9 @@ postgresql:
       repository: bitnami-shell-archived
   primary:
     persistence:
-      enabled: true # Needed to play nice with pgvector data
-      mountPath: /bitnami/postgres
+      # -- (bool) Whether to enable persistence, required to play nice with pgvector container.
+      enabled: true
+      mountPath: /bitnami/postgresql
 
 elasticsearch:
   image: "quay.io/cdis/elasticsearch"

--- a/helm/gen3/values.yaml
+++ b/helm/gen3/values.yaml
@@ -418,12 +418,18 @@ access-backend:
 # Disable persistence by default so we can spin up and down ephemeral environments
 postgresql:
   image:
-    repository: bitnamilegacy/postgresql
-    tag: 16.6.0-debian-12-r2
+    repository: pgvector/pgvector
+    tag: pg16
+    debug: true # FIXME11-debian-11-r45
+  volumePermissions:
+    enabled: true
+    image:
+      registry: bitnamilegacy
+      repository: bitnami-shell-archived
   primary:
     persistence:
-      # -- (bool) Option to persist the dbs data.
-      enabled: false
+      enabled: true # Needed to play nice with pgvector data
+      mountPath: /bitnami/postgres
 
 elasticsearch:
   image: "quay.io/cdis/elasticsearch"


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one:
[GPE-2406](https://ctds-planx.atlassian.net/browse/GPE-2406?atlOrigin=eyJpIjoiZjg4N2FiODk4ZjRjNGNiMjkzODdhZWYzYjkzYTEwYWMiLCJwIjoiaiJ9)

### New Features
Changes the default container from bitnami postgres to pgvector. Same debian, same major PG version.

### Breaking Changes
Persistence has to be enabled, which is NOT going to be great for local dev. I.e. have to blow away entire namespaces not just helm uninstall.

Here's the block of bitnami templated yaml to [fight](https://github.com/bitnami/charts/blob/78410dd9a56a206cc63884f1500c03358faa8528/bitnami/postgresql/templates/primary/statefulset.yaml#L120-L159)

### Bug Fixes

### Improvements

### Dependency updates
Postgres Chart updated with pre-commit hooks.

### How I verified:
Got kind up and running and ran two gen3's locally in namespaces `novector` no changes and `yesvector` these changes both eventually stabilized. Note keeping this is draft until I can verify the pgaudit extension is installed in `yesvector`. 

Concerning log lines:
OLD:
```
postgresql 18:57:03.88 INFO  ==> ** Starting PostgreSQL **
2026-06-09 18:57:03.891 GMT [1] LOG:  pgaudit extension initialized
2026-06-09 18:57:03.894 GMT [1] LOG:  starting PostgreSQL 16.6 on aarch64-unknown-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
TRUNCATED
        Connection matched file "/opt/bitnami/postgresql/conf/pg_hba.conf" line 1: "host     all             all             0.0.0.0/0               md5"
2026-06-09 18:57:26.741 GMT [268] ERROR:  relation "db_version" does not exist at character 21
2026-06-09 18:57:26.741 GMT [268] STATEMENT:  select version from db_version
```

NEW:
```
PostgreSQL init process complete; ready for start up.

2026-06-09 21:05:30.448 UTC [1] LOG:  starting PostgreSQL 16.14 (Debian 16.14-1.pgdg12+1) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 12.2.0-14+deb12u1) 12.2.0, 64-bit
TRUNCATED
        Connection matched file "/bitnami/postgresql/data/pg_hba.conf" line 128: "host all all all scram-sha-256"
2026-06-09 21:05:56.766 UTC [190] ERROR:  relation "db_version" does not exist at character 21
2026-06-09 21:05:56.766 UTC [190] STATEMENT:  select version from db_version
2026-06-09 21:05:58.128 UTC [198] ERROR:  relation "authorization_provider" does not exist at character 203
2026-06-09 21:05:58.128 UTC [198] STATEMENT:  SELECT authorization_provider.id AS authorization_provider_id, authorization_provider.name AS authorization_provider_name, authorization_provider.description AS authorization_provider_description
        FROM authorization_provider
        WHERE authorization_provider.name = 'dbGaP'
         LIMIT 1
```
Logs say
- upgrading pg from 16.6 -> 16.16 
- I don't see the pgaudit extension getting logged in the new one.
- connection match file changed from md5 to scram-sha256, which is certainly a heavier hash.
- when running locally I saw the authorization_provider.name dbGap only in the new, which we might not want. 


<!-- This section should only contain important things devops should know when updating service versions. -->


[GPE-2406]: https://ctds-planx.atlassian.net/browse/GPE-2406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ