### PR TITLE
feat(merge_conflict_check): update to 4.2.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,10 +7,12 @@ repos:
         additional_dependencies: ["gibberish-detector"]
   
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v4.2.0
     hooks:
-      - id: no-commit-to-branch
-        args: [--branch, develop, --branch, master, --pattern, release/.*]
+        - id: no-commit-to-branch
+          args: [--branch, develop, --branch, master, --branch, main, --pattern, release/.*]
+        - id: check-merge-conflict
+        - id: end-of-file-fixer
 
   # - repo: https://github.com/gruntwork-io/pre-commit
   #   rev: v0.1.17 # Get the latest from: https://github.com/gruntwork-io/pre-commit/releases


### PR DESCRIPTION

Link to JIRA ticket if there is one:

### New Features
 - modifying pre-commit run so we churn quicker on updates
 
 I took this list from meta's precommit hooks. The idea being if you conflict with the branch your going into we'll know locally not when the lint step happens. Also protect main
