### PR TITLE
Fix/pass root context to checksum calculator

### DIFF
--- a/helm/cohort-middleware/templates/deployment.yaml
+++ b/helm/cohort-middleware/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     metadata:
       {{- with .Values.podAnnotations }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/secrets.yaml") $ | sha256sum }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/helm/etl/templates/etl-job.yaml
+++ b/helm/etl/templates/etl-job.yaml
@@ -13,7 +13,7 @@ spec:
           {{- with .Values.podAnnotations }}
           annotations:
             {{- toYaml . | nindent 12 }}
-            checksum/config: {{ include (print $.Template.BasePath "/etl-mapping.yaml") . | sha256sum }}
+            checksum/config: {{ include (print $.Template.BasePath "/etl-mapping.yaml") $ | sha256sum }}
           {{- end }}
           labels:
             app: gen3job


### PR DESCRIPTION
Bug arises when you fill podAnnotations (by default, they are empty).
The checksum/config line lives inside `{{- with .Values.podAnnotations }}`. 
With rebinds  the dot, so `{{ include "…/etl-mapping.yaml" . }}` was handing the include the podAnnotations map as its context instead of the chart root. 
Inside etl-mapping.yaml and cohort-middleware deployment `.Values.etlMapping` then resolved against that map → nil → render failure.
 


<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one:

### New Features

### Breaking Changes

### Bug Fixes
Fix checksum calculator to work on root context

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
