### PR TITLE
feat(revproxy): add customNginxConfigs to extraServices for per-servi…

### DIFF
--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -116,7 +116,7 @@ dependencies:
     repository: "file://../requestor"
     condition: requestor.enabled
   - name: revproxy
-    version: 0.1.66
+    version: 0.1.67
     repository: "file://../revproxy"
     condition: revproxy.enabled
   - name: sheepdog
@@ -213,7 +213,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.3.69
+version: 0.3.70
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/gen3/README.md
+++ b/helm/gen3/README.md
@@ -1,6 +1,6 @@
 # gen3
 
-![Version: 0.3.69](https://img.shields.io/badge/Version-0.3.69-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.3.70](https://img.shields.io/badge/Version-0.3.70-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 Helm chart to deploy Gen3 Data Commons
 
@@ -55,7 +55,7 @@ Helm chart to deploy Gen3 Data Commons
 | file://../peregrine | peregrine | 0.1.44 |
 | file://../portal | portal | 0.1.62 |
 | file://../requestor | requestor | 0.1.36 |
-| file://../revproxy | revproxy | 0.1.66 |
+| file://../revproxy | revproxy | 0.1.67 |
 | file://../sheepdog | sheepdog | 0.1.45 |
 | file://../sower | sower | 0.1.48 |
 | file://../ssjdispatcher | ssjdispatcher | 0.1.49 |

--- a/helm/revproxy/Chart.yaml
+++ b/helm/revproxy/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.66
+version: 0.1.67
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/revproxy/README.md
+++ b/helm/revproxy/README.md
@@ -1,6 +1,6 @@
 # revproxy
 
-![Version: 0.1.66](https://img.shields.io/badge/Version-0.1.66-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.67](https://img.shields.io/badge/Version-0.1.67-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for gen3 revproxy
 

--- a/helm/revproxy/templates/configMaps.yaml
+++ b/helm/revproxy/templates/configMaps.yaml
@@ -48,6 +48,9 @@ data:
 
         set $proxy_service "{{ .name }}";
         set $upstream http://{{ .serviceName }}$des_domain;
+        {{- if .customNginxConfigs }}
+{{ "\n        " }}{{- .customNginxConfigs | trim | replace "\n" "\n        " }}
+{{- end }}
         rewrite ^{{ .path }}/(.*) /$1 break;
         proxy_pass $upstream;
         proxy_redirect http://$host/ https://$host{{ .path }}/;

--- a/helm/revproxy/values.yaml
+++ b/helm/revproxy/values.yaml
@@ -270,6 +270,11 @@ extraServices:
 #    authzPolicy: "protein-paint"
 #    authzService: "protein-paint"
 #    csrfCheck: true
+#    customNginxConfigs: |
+#      proxy_buffering off;
+#      proxy_cache off;
+#      proxy_read_timeout 1h;
+#      proxy_send_timeout 1h;
 
 # -- (map) Raw nginx location blocks to add or override entries in the revproxy-nginx-subconf ConfigMap.
 # Keys are the conf filename (e.g. "guppy-service.conf"). A key matching a built-in static conf file


### PR DESCRIPTION
Add custom Nginx Configs to extra services for per-service nginx directives

Allow extraServices entries to inject custom nginx directives into the generated location block before proxy_pass. Useful for SSE settings (proxy_buffering, proxy_read_timeout), caching overrides, etc.

Auto-indents user content to match location block nesting.

<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one:

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
