### PR TITLE
fix root context and checksum/config annotation scope in ETL and cohort-middleware charts

### DIFF
--- a/helm/cohort-middleware/Chart.yaml
+++ b/helm/cohort-middleware/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.24
+version: 0.1.25
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/cohort-middleware/README.md
+++ b/helm/cohort-middleware/README.md
@@ -114,3 +114,4 @@ A Helm chart for gen3 cohort-middleware
 | tolerations | list | `[]` |  |
 | volumeMounts | list | `[]` |  |
 | volumes | string | `nil` |  |
+

--- a/helm/cohort-middleware/README.md
+++ b/helm/cohort-middleware/README.md
@@ -114,4 +114,3 @@ A Helm chart for gen3 cohort-middleware
 | tolerations | list | `[]` |  |
 | volumeMounts | list | `[]` |  |
 | volumes | string | `nil` |  |
-

--- a/helm/cohort-middleware/README.md
+++ b/helm/cohort-middleware/README.md
@@ -1,6 +1,6 @@
 # cohort-middleware
 
-![Version: 0.1.24](https://img.shields.io/badge/Version-0.1.24-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.25](https://img.shields.io/badge/Version-0.1.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for gen3 cohort-middleware
 

--- a/helm/cohort-middleware/templates/deployment.yaml
+++ b/helm/cohort-middleware/templates/deployment.yaml
@@ -85,3 +85,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+

--- a/helm/cohort-middleware/templates/deployment.yaml
+++ b/helm/cohort-middleware/templates/deployment.yaml
@@ -15,11 +15,11 @@ spec:
       {{- include "cohort-middleware.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         dbohdsi: "yes"
         dbomop-data: "yes"

--- a/helm/etl/Chart.yaml
+++ b/helm/etl/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.23
+version: 0.1.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/etl/README.md
+++ b/helm/etl/README.md
@@ -1,6 +1,6 @@
 # etl
 
-![Version: 0.1.23](https://img.shields.io/badge/Version-0.1.23-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.24](https://img.shields.io/badge/Version-0.1.24-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for gen3 etl
 

--- a/helm/etl/templates/etl-job.yaml
+++ b/helm/etl/templates/etl-job.yaml
@@ -10,11 +10,11 @@ spec:
       backoffLimit: 0
       template:
         metadata:
-          {{- with .Values.podAnnotations }}
           annotations:
-            {{- toYaml . | nindent 12 }}
             checksum/config: {{ include (print $.Template.BasePath "/etl-mapping.yaml") . | sha256sum }}
-          {{- end }}
+            {{- with .Values.podAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           labels:
             app: gen3job
         spec:

--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -213,7 +213,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.3.72
+version: 0.3.73
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -37,7 +37,7 @@ dependencies:
     repository: "file://../cedar"
     condition: cedar.enabled
   - name: cohort-middleware
-    version: 0.1.24
+    version: 0.1.25
     repository: "file://../cohort-middleware"
     condition: cohort-middleware.enabled
   - name: common
@@ -60,7 +60,7 @@ dependencies:
     repository: file://../embedding-management-service
     condition: embedding-management-service.enabled
   - name: etl
-    version: 0.1.23
+    version: 0.1.24
     repository: file://../etl
     condition: etl.enabled
   - name: frontend-framework
@@ -213,7 +213,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.3.69
+version: 0.3.70
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/gen3/README.md
+++ b/helm/gen3/README.md
@@ -1,6 +1,6 @@
 # gen3
 
-![Version: 0.3.72](https://img.shields.io/badge/Version-0.3.72-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.3.73](https://img.shields.io/badge/Version-0.3.73-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 Helm chart to deploy Gen3 Data Commons
 

--- a/helm/gen3/README.md
+++ b/helm/gen3/README.md
@@ -1,6 +1,6 @@
 # gen3
 
-![Version: 0.3.69](https://img.shields.io/badge/Version-0.3.69-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.3.70](https://img.shields.io/badge/Version-0.3.70-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 Helm chart to deploy Gen3 Data Commons
 
@@ -26,14 +26,14 @@ Helm chart to deploy Gen3 Data Commons
 | file://../aws-es-proxy | aws-es-proxy | 0.1.43 |
 | file://../aws-sigv4-proxy | aws-sigv4-proxy | 0.1.4 |
 | file://../cedar | cedar | 0.1.28 |
-| file://../cohort-middleware | cohort-middleware | 0.1.24 |
+| file://../cohort-middleware | cohort-middleware | 0.1.25 |
 | file://../common | common | 0.1.38 |
 | file://../dashboard | dashboard | 0.1.23 |
 | file://../data-upload-cron | data-upload-cron | 0.1.8 |
 | file://../datareplicate | datareplicate | 0.1.23 |
 | file://../dicom-server | dicom-server | 0.1.33 |
 | file://../embedding-management-service | embedding-management-service | 0.1.10 |
-| file://../etl | etl | 0.1.23 |
+| file://../etl | etl | 0.1.24 |
 | file://../fence | fence | 0.1.80 |
 | file://../frontend-framework | frontend-framework | 0.1.31 |
 | file://../funnel | funnel | 0.1.28 |


### PR DESCRIPTION
`checksum/config` was nested inside `{{- with .Values.podAnnotations }}`, which rebinds `.`  breaking the checksum's `include` call when `podAnnotations` is set, and silently omitting the annotation entirely when it's not.

Moved `checksum/config` outside the `with` block.

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
