### PR TITLE
Feat/usersync prune option

### DIFF
--- a/helm/fence/templates/usersync-cron.yaml
+++ b/helm/fence/templates/usersync-cron.yaml
@@ -264,10 +264,14 @@ spec:
                 chmod 400 ~/.ssh/id*
                 
                 python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml /var/www/fence/fence-config.yaml
+                # Pass an arborist-pruning flag only when pruneUsers is set to a Boolean
+                # (requires fence-create support from uc-cdis/fence#1368). Unset -> empty
+                # -> stock fence behaviour is unchanged.
+                PRUNE_FLAG="{{ if kindIs "bool" .Values.usersync.pruneUsers }}{{ ternary "--prune-users" "--no-prune-users" .Values.usersync.pruneUsers }}{{ end }}"
                 if [[ "$SYNC_FROM_DBGAP" != "true" && "$ADD_DBGAP" != "true" ]]; then
                   if [[ -f /mnt/shared/user.yaml ]]; then
                     echo "running fence-create"
-                    time fence-create sync --arborist http://arborist-service --yaml /mnt/shared/user.yaml
+                    time fence-create sync --arborist http://arborist-service --yaml /mnt/shared/user.yaml $PRUNE_FLAG
                   else
                     echo "/mnt/shared/user.yaml did not appear within timeout :-("
                     false  # non-zero exit code
@@ -277,10 +281,10 @@ spec:
                   output=$(mktemp "/tmp/fence-create-output_XXXXXX")
                   if [[ -f /mnt/shared/user.yaml && "$ONLY_DBGAP" != "true" ]]; then
                     echo "Running fence-create dbgap-sync with user.yaml - see $output"
-                    time fence-create sync --arborist http://arborist-service --sync_from_dbgap "True" --projects /var/www/fence/projects.yaml --yaml /mnt/shared/user.yaml 2>&1 | tee "$output"
+                    time fence-create sync --arborist http://arborist-service --sync_from_dbgap "True" --projects /var/www/fence/projects.yaml --yaml /mnt/shared/user.yaml $PRUNE_FLAG 2>&1 | tee "$output"
                   else
                     echo "Running fence-create dbgap-sync without user.yaml - see $output"
-                    time fence-create sync --arborist http://arborist-service --sync_from_dbgap "True" --projects /var/www/fence/projects.yaml 2>&1 | tee "$output"
+                    time fence-create sync --arborist http://arborist-service --sync_from_dbgap "True" --projects /var/www/fence/projects.yaml $PRUNE_FLAG 2>&1 | tee "$output"
                   fi
                   exitcode="${PIPESTATUS[0]}"
                   echo "$output"

--- a/helm/fence/templates/useryaml-job.yaml
+++ b/helm/fence/templates/useryaml-job.yaml
@@ -1,10 +1,14 @@
-kind: ConfigMap 
-apiVersion: v1 
+kind: ConfigMap
+apiVersion: v1
 metadata:
   name: useryaml
-data: 
-  useryaml: {{ .Values.USER_YAML | toYaml | nindent 4}}
+data:
+  useryaml: {{ .Values.USER_YAML | toYaml | nindent 4 }}
 ---
+{{- $pruneFlag := "" -}}
+{{- if kindIs "bool" .Values.usersync.pruneUsers -}}
+{{- $pruneFlag = ternary "--prune-users" "--no-prune-users" .Values.usersync.pruneUsers -}}
+{{- end -}}
 {{ if not .Values.usersync.usersync }}
 apiVersion: batch/v1
 kind: Job
@@ -21,29 +25,32 @@ spec:
       volumes:
         - name: fence-config
           secret:
-            secretName: "fence-config"
+            secretName: fence-config
         - name: useryaml
           configMap:
             name: useryaml
       containers:
-      - name: fence
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-        imagePullPolicy: Always
-        env:
-          {{- toYaml .Values.env | nindent 10 }}
-        volumeMounts:
-          - name: "fence-config"
-            readOnly: true
-            mountPath: "/var/www/fence/fence-config.yaml"
-            subPath: fence-config.yaml
-          - name: "useryaml"
-            mountPath: "/var/www/fence/user.yaml"
-            subPath: useryaml
-        command: ["/bin/bash" ]
-        args:
-          - "-c"
-          # Script always succeeds if it runs (echo exits with 0)
-          - |
-            fence-create sync --arborist http://arborist-service --yaml /var/www/fence/user.yaml
+        - name: fence
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: Always
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          volumeMounts:
+            - name: fence-config
+              readOnly: true
+              mountPath: /var/www/fence/fence-config.yaml
+              subPath: fence-config.yaml
+            - name: useryaml
+              mountPath: /var/www/fence/user.yaml
+              subPath: useryaml
+          command: ["/bin/bash"]
+          args:
+            - "-c"
+            - |
+              # Only pass a pruning flag when explicitly configured as a Boolean.
+              # Omitting the flag preserves compatibility with older Fence versions.
+              fence-create sync \
+                --arborist http://arborist-service \
+                --yaml /var/www/fence/user.yaml{{ if $pruneFlag }} {{ $pruneFlag }}{{ end }}
       restartPolicy: OnFailure
 {{ end }}

--- a/helm/fence/values.yaml
+++ b/helm/fence/values.yaml
@@ -150,6 +150,11 @@ usersync:
   # -- (bool) Whether Arborist users with no remaining user-specific policies
   # should be removed during usersync.
   #
+  # Scope: this gates USER pruning only. On every run, usersync still reconciles
+  # the authz model from user.yaml regardless of this value: groups absent from
+  # user.yaml are deleted, and user policy bindings are revoked and re-applied.
+  # Setting this to false does NOT make usersync non-destructive to groups or policies.
+  #
   # Set to false for deployments using dynamic user management
   # (e.g. Auth0 or REMS).
   # true: pass --prune-users; requires a Fence version supporting the flag.
@@ -876,7 +881,7 @@ FENCE_CONFIG:
   OPENID_CONNECT:
     # any OIDC IDP that does not differ from the generic implementation can be
     # configured without code changes
-    generic_oidc_idp: # choose a unique ID and replace this key
+    generic_oidc_idp:  # choose a unique ID and replace this key
       # -- (str) Optional; display name for this IDP
       name: "some_idp"
       # -- (str) Client ID
@@ -884,7 +889,7 @@ FENCE_CONFIG:
       # -- (str) Client secret
       client_secret: ""
       # -- (str) Redirect URL for this IDP
-      redirect_url: "{{BASE_URL}}/login/some_idp/login" # replace IDP name
+      redirect_url: "{{BASE_URL}}/login/some_idp/login"  # replace IDP name
       # use `discovery` to configure IDPs that do not expose a discovery
       # endpoint. One of `discovery_url` or `discovery` should be configured
       # -- (str) URL of the OIDC discovery endpoint for the IDP

--- a/helm/fence/values.yaml
+++ b/helm/fence/values.yaml
@@ -147,6 +147,15 @@ externalSecrets:
 usersync:
   # -- (bool) Whether to run Fence usersync or not.
   usersync: false
+  # -- (bool) Whether Arborist users with no remaining user-specific policies
+  # should be removed during usersync.
+  #
+  # Set to false for deployments using dynamic user management
+  # (e.g. Auth0 or REMS).
+  # true: pass --prune-users; requires a Fence version supporting the flag.
+  # false: pass --no-prune-users; requires a Fence version supporting the flag.
+  # null: do not pass a pruning flag; compatible with older Fence images.
+  pruneUsers: null
   # -- (string) The cron schedule expression to use in the usersync cronjob. Runs every 30 minutes by default.
   schedule: "*/30 * * * *"
   # -- (string) To set a custom image for pulling the user.yaml file from S3. Default is the Gen3 Awshelper image.
@@ -277,8 +286,7 @@ podAnnotations: {}
 podSecurityContext: {}
 
 # -- (map) Security context for the containers in the pod
-securityContext:
-  {}
+securityContext: {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -868,7 +876,7 @@ FENCE_CONFIG:
   OPENID_CONNECT:
     # any OIDC IDP that does not differ from the generic implementation can be
     # configured without code changes
-    generic_oidc_idp:  # choose a unique ID and replace this key
+    generic_oidc_idp: # choose a unique ID and replace this key
       # -- (str) Optional; display name for this IDP
       name: "some_idp"
       # -- (str) Client ID
@@ -876,7 +884,7 @@ FENCE_CONFIG:
       # -- (str) Client secret
       client_secret: ""
       # -- (str) Redirect URL for this IDP
-      redirect_url: "{{BASE_URL}}/login/some_idp/login"  # replace IDP name
+      redirect_url: "{{BASE_URL}}/login/some_idp/login" # replace IDP name
       # use `discovery` to configure IDPs that do not expose a discovery
       # endpoint. One of `discovery_url` or `discovery` should be configured
       # -- (str) URL of the OIDC discovery endpoint for the IDP

--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -217,11 +217,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-<<<<<<< HEAD
 version: 0.0.0
-=======
-version: 0.3.79
->>>>>>> be1c7fb5 (chore: version bump)
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -217,7 +217,11 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
+<<<<<<< HEAD
 version: 0.0.0
+=======
+version: 0.3.79
+>>>>>>> be1c7fb5 (chore: version bump)
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

### Improvements
Add explicit CLI control to fence-create sync:

```
--prune-users
--no-prune-users
```
Behavior:

```
--prune-users: preserve current behavior for backward compatibility.
--no-prune-users: preserve Arborist identities that have no remaining non-generic policies.
```
### Scope of this flag
`pruneUsers` controls arborist user pruning only — it maps to `remove_users_with_no_policie`s in fence's usersync, i.e. whether a user left with no policies is deleted from arborist.
It does not change the rest of the sync. On every run, `_update_arborist` still reconciles the authz model from user.yaml regardless of this setting: groups not present in user.yaml are deleted (except built-in `anonymous/logged-in`), and user policy bindings are revoked and re-applied. So `--no-prune-users` prevents user removal but does not make usersync non-destructive to groups or policies.
Freezing the wider authz model (e.g. group pruning) would be a separate, larger change and is intentionally out of scope here.
Requires a Fence build that supports the `--prune-users/--no-prune-users` flags (uc-cdis/fence#1368). With `pruneUsers: null` (default) no flag is passed, so the chart remains compatible with older Fence images.
The default remains pruning enabled in the initial PR to avoid changing existing deployments silently. Dynamic deployments must opt out explicitly.

Details: https://github.com/uc-cdis/fence/issues/1367

<!-- This section should only contain important things devops should know when updating service versions. -->
