### PR TITLE
fix(BDC-1250): Adds default preferred_type for DRS 1.5

### DIFF
--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -217,7 +217,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.3.81
+version: 0.3.82
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -96,7 +96,7 @@ dependencies:
     repository: "file://../hatchery"
     condition: hatchery.enabled
   - name: indexd
-    version: 0.1.50
+    version: 0.1.51
     repository: "file://../indexd"
     condition: indexd.enabled
   - name: manifestservice
@@ -120,7 +120,7 @@ dependencies:
     repository: "file://../requestor"
     condition: requestor.enabled
   - name: revproxy
-    version: 0.1.70
+    version: 0.1.71
     repository: "file://../revproxy"
     condition: revproxy.enabled
   - name: sheepdog

--- a/helm/gen3/README.md
+++ b/helm/gen3/README.md
@@ -44,7 +44,7 @@ Helm chart to deploy Gen3 Data Commons
 | file://../gen3-workflow | gen3-workflow | 0.1.29 |
 | file://../guppy | guppy | 0.1.41 |
 | file://../hatchery | hatchery | 0.1.73 |
-| file://../indexd | indexd | 0.1.50 |
+| file://../indexd | indexd | 0.1.51 |
 | file://../jeg | jeg | 0.1.4 |
 | file://../manifestservice | manifestservice | 0.1.46 |
 | file://../metadata | metadata | 0.1.48 |
@@ -56,7 +56,7 @@ Helm chart to deploy Gen3 Data Commons
 | file://../peregrine | peregrine | 0.1.45 |
 | file://../portal | portal | 0.1.63 |
 | file://../requestor | requestor | 0.1.38 |
-| file://../revproxy | revproxy | 0.1.70 |
+| file://../revproxy | revproxy | 0.1.71 |
 | file://../sheepdog | sheepdog | 0.1.47 |
 | file://../sower | sower | 0.1.49 |
 | file://../ssjdispatcher | ssjdispatcher | 0.1.50 |

--- a/helm/gen3/README.md
+++ b/helm/gen3/README.md
@@ -1,6 +1,6 @@
 # gen3
 
-![Version: 0.3.81](https://img.shields.io/badge/Version-0.3.81-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.3.82](https://img.shields.io/badge/Version-0.3.82-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 Helm chart to deploy Gen3 Data Commons
 

--- a/helm/indexd/Chart.yaml
+++ b/helm/indexd/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.50
+version: 0.1.51
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/indexd/README.md
+++ b/helm/indexd/README.md
@@ -1,6 +1,6 @@
 # indexd
 
-![Version: 0.1.50](https://img.shields.io/badge/Version-0.1.50-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.51](https://img.shields.io/badge/Version-0.1.51-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for gen3 indexd
 
@@ -114,9 +114,10 @@ A Helm chart for gen3 indexd
 | serviceAccount.create | bool | `false` | Specifies whether a service account should be created. |
 | serviceAccount.name | string | `""` | The name of the service account |
 | tolerations | list | `[]` | Tolerations for the pods |
-| trustedIssuers | map | `{"defaultBearerIssuer":"","defaultPassportIssuer":""}` | Maps an arborist resource to the issuers for passports and bearer tokens. |
+| trustedIssuers | map | `{"defaultBearerIssuer":"","defaultPassportIssuer":"","defaultPreferredType":"BearerAuth"}` | Maps an arborist resource to the issuers for passports and bearer tokens. |
 | trustedIssuers.defaultBearerIssuer | string | `""` | The default issuer for bearer tokens to be used if a given auth resource isn't provided. Defaults to the fence token issuer |
 | trustedIssuers.defaultPassportIssuer | string | `""` | The default issuer for passports to be used if a given auth resource isn't provided. |
+| trustedIssuers.defaultPreferredType | string | `"BearerAuth"` | The default preferred supported_type. This will ensure indexd return this supported_type before the other. |
 | useSingleTable | string | `"False"` |  |
 | uwsgi | map | `{"listen":1024}` | Values for overriding uwsgi settings |
 | volumeMounts | list | `[{"mountPath":"/etc/uwsgi/uwsgi.ini","name":"uwsgi-config","subPath":"uwsgi.ini"},{"mountPath":"/var/www/indexd/local_settings.py","name":"config-volume","readOnly":true,"subPath":"local_settings.py"},{"mountPath":"/indexd/deployment/wsgi/gunicorn.conf.py","name":"gunicorn-conf","readOnly":true,"subPath":"gunicorn.conf.py"}]` | Volumes to mount to the container. |

--- a/helm/indexd/indexd-settings/local_settings.py
+++ b/helm/indexd/indexd-settings/local_settings.py
@@ -106,4 +106,9 @@ default_passport_issuer = environ.get("DEFAULT_PASSPORT_ISSUER", None)
 if default_passport_issuer:
     CONFIG["DEFAULT_PASSPORT_ISSUER"] = default_passport_issuer
 
+default_preferred_type = environ.get("DEFAULT_PREFERRED_TYPE", None)
+
+if default_preferred_type:
+    CONFIG["DEFAULT_PREFERRED_TYPE"] = default_preferred_type
+
 settings = {"config": CONFIG, "auth": AUTH}

--- a/helm/indexd/templates/deployment.yaml
+++ b/helm/indexd/templates/deployment.yaml
@@ -94,6 +94,8 @@ spec:
               value: {{ default (printf "https://%s/user" .Values.global.hostname) .Values.trustedIssuers.defaultBearerIssuer | quote }}
             - name: DEFAULT_PASSPORT_ISSUER
               value: {{ .Values.trustedIssuers.defaultPassportIssuer | quote }}
+            - name: DEFAULT_PREFERRED_TYPE
+              value: {{ .Values.trustedIssuers.defaultPreferredType | quote }}
             - name: CLOUD_PROVIDER_MAP
               value: {{ .Values.cloudProviderMap | toJson | quote }}
             {{- toYaml .Values.env | nindent 12  }}

--- a/helm/indexd/values.yaml
+++ b/helm/indexd/values.yaml
@@ -297,12 +297,15 @@ cloudProviderMap:
 
 # -- (map) Maps an arborist resource to the issuers for passports and bearer tokens.
 trustedIssuers:
+  # -- (string) The default preferred supported_type. This will ensure indexd return this supported_type before the other.
+  defaultPreferredType: "BearerAuth"
   # -- (string) The default issuer for bearer tokens to be used if a given auth resource isn't provided. Defaults to the fence token issuer
   defaultBearerIssuer: ""
   # -- (string) The default issuer for passports to be used if a given auth resource isn't provided.
   defaultPassportIssuer: ""
   # Example:
   #   "/programs/parent":
+  #     preferred_type: "PassportAuth"
   #     passport_auth_issuers:
   #       - "https://stsstg.nih.gov"
   #     bearer_auth_issuers:

--- a/helm/revproxy/Chart.yaml
+++ b/helm/revproxy/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.70
+version: 0.1.71
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/revproxy/README.md
+++ b/helm/revproxy/README.md
@@ -1,6 +1,6 @@
 # revproxy
 
-![Version: 0.1.70](https://img.shields.io/badge/Version-0.1.70-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.71](https://img.shields.io/badge/Version-0.1.71-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for gen3 revproxy
 

--- a/helm/revproxy/gen3.nginx.conf/fence-service-ga4gh.conf
+++ b/helm/revproxy/gen3.nginx.conf/fence-service-ga4gh.conf
@@ -11,3 +11,17 @@ location ~ \/ga4gh\/drs\/v1\/objects\/(.*)\/access {
     proxy_connect_timeout       400;
     proxy_pass $upstream;
 }
+
+location ~ \/ga4gh\/drs\/v1\/objects\/access {
+    if ($csrf_check !~ ^ok-\S.+$) {
+      return 403 "failed csrf check";
+    }
+
+    set $proxy_service  "presigned-url-fence";
+    set $upstream http://presigned-url-fence-service$des_domain;
+    rewrite ^/user/(.*) /$1 break;
+    proxy_read_timeout          400;
+    proxy_send_timeout          400;
+    proxy_connect_timeout       400;
+    proxy_pass $upstream;
+}


### PR DESCRIPTION
Adds configuration to indexd trustedIssuers to support changing the order of the supportedTypes returned by the DRS Authorization endpoints.

Updates revproxy to forward bulk DRS object access requests to fence instead of indexd.

<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one:

### New Features
- Adds update to trustedIssuers in indexd to support configuring the preferred supported_type, allowing DRS services to set the credential DRS clients should attempt to use first. 
### Breaking Changes

### Bug Fixes
- Fix revproxy so DRS bulk object access endpoint forwards to fence instead of indexd.
- Fix issue where BearerAuth was always the first supported_type. 
### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
