### PR TITLE
Fix funnel 'replicas' to use configured value

### DIFF
--- a/helm/funnel/Chart.yaml
+++ b/helm/funnel/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.32
+version: 0.1.33
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/funnel/README.md
+++ b/helm/funnel/README.md
@@ -1,6 +1,6 @@
 # funnel
 
-![Version: 0.1.32](https://img.shields.io/badge/Version-0.1.32-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.1.33](https://img.shields.io/badge/Version-0.1.33-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/helm/funnel/templates/server-deployment.yaml
+++ b/helm/funnel/templates/server-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "funnel.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/helm/funnel/values.yaml
+++ b/helm/funnel/values.yaml
@@ -133,7 +133,6 @@ image:
   # -- (string) When to pull the image. This value should be "Always" to ensure the latest image is used.
   pullPolicy: Always
 
-
   # -- (map) Configuration for the Funnel init container.
   initContainers:
     - name: plugin

--- a/helm/gen3/Chart.yaml
+++ b/helm/gen3/Chart.yaml
@@ -72,7 +72,7 @@ dependencies:
     repository: "file://../fence"
     condition: fence.enabled
   - name: funnel
-    version: 0.1.32
+    version: 0.1.33
     repository: "file://../funnel"
     condition: gen3-workflow.enabled
   - name: gen3-embeddings
@@ -217,7 +217,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.3.80
+version: 0.3.81
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/gen3/README.md
+++ b/helm/gen3/README.md
@@ -1,6 +1,6 @@
 # gen3
 
-![Version: 0.3.80](https://img.shields.io/badge/Version-0.3.80-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 0.3.81](https://img.shields.io/badge/Version-0.3.81-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 Helm chart to deploy Gen3 Data Commons
 
@@ -36,7 +36,7 @@ Helm chart to deploy Gen3 Data Commons
 | file://../etl | etl | 0.1.24 |
 | file://../fence | fence | 0.1.82 |
 | file://../frontend-framework | frontend-framework | 0.1.32 |
-| file://../funnel | funnel | 0.1.32 |
+| file://../funnel | funnel | 0.1.33 |
 | file://../gen3-analysis | gen3-analysis | 0.1.15 |
 | file://../gen3-embeddings | gen3-embeddings | 0.1.1 |
 | file://../gen3-network-policies | gen3-network-policies | 0.1.4 |


### PR DESCRIPTION
https://github.com/uc-cdis/gen3-helm/pull/635 and https://github.com/uc-cdis/gen3-helm/pull/637 seem to have changed the original config ([here](https://github.com/calypr/helm-charts/blob/53d79276ffe3754163a7d6b8c424267520bed6b3/charts/funnel/templates/server-deployment.yaml#L9)) and hardcoded the value to 1 instead of using the configured value.

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
