### PR TITLE
Fix invalid JSON in gen3-workflow crossplane policy document

### DIFF
--- a/helm/gen3-workflow/templates/crossplane.yaml
+++ b/helm/gen3-workflow/templates/crossplane.yaml
@@ -181,7 +181,7 @@ spec:
               "events:ListTargetsByRule"
             ],
             "Resource": "arn:aws:events:*:{{ .Values.global.crossplane.accountId }}:rule/*"
-          },
+          }
         ]
       }
 ---


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one:

### New Features

### Breaking Changes

### Bug Fixes
The IAM policy document in helm/gen3-workflow/templates/crossplane.yaml has a trailing comma after the last statement (AddEventBridgeRulesForS3Files), making the rendered JSON invalid. Crossplane fails with \`MalformedPolicyDocument: Syntax errors in policy\`, so the gen3-workflow service account role gets no permissions on any newly deployed env. Hit at runtime as \`AccessDeniedException ... eks:DescribeCluster\` on piotr.planx-pla.net.
### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
