### PR TITLE
fail config-puller initContainer on command errors

### DIFF
--- a/helm/frontend-framework/templates/deployment.yaml
+++ b/helm/frontend-framework/templates/deployment.yaml
@@ -60,6 +60,7 @@ spec:
             - /bin/sh
             - -c
             - |
+              set -eu
               echo "Starting config puller initContainer"
 
               mkdir -p /tmp/repo


### PR DESCRIPTION
This PR updates the Frontend Framework `config-puller` initContainer to fail immediately when a required command fails.

The issue was observed during Frontend Framework startup when a **transient DNS/network issue** prevented the initContainer from reaching GitHub. The `git clone` command failed with:

`Could not resolve host: github.com`

However, the script continued executing and eventually exited successfully, allowing the Frontend Framework to start without the required configuration files.

#### Changes

* Added `set -eu` to the `config-puller` shell script.
* Ensures failures such as `git clone`, sparse checkout, or config copy result in a non-zero exit code.
* Prevents the Frontend Framework from starting when required configuration cannot be retrieved.
* Allows Kubernetes to retry the failed initContainer so initialization can succeed once the transient network issue is resolved.
