### PR TITLE
Fix frontend-framework crashloop by setting the container command

### DIFF
--- a/helm/frontend-framework/templates/deployment.yaml
+++ b/helm/frontend-framework/templates/deployment.yaml
@@ -108,6 +108,10 @@ spec:
         - name: frontend-framework
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               {{- if eq "portal" .Values.global.frontendRoot }}

--- a/helm/frontend-framework/values.yaml
+++ b/helm/frontend-framework/values.yaml
@@ -81,6 +81,15 @@ metricsEnabled:
 # -- (int) Number of replicas for the deployment.
 replicaCount: 1
 
+# -- (list) Overrides the container's entrypoint. The image's own CMD is
+# `./start_with_config.sh`, which recent commons-frontend-app builds no longer ship - only
+# /gen3/start.sh - so the container exits immediately with "can't open
+# ./start_with_config.sh". start.sh runs the same standalone server and tolerates a missing
+# config directory, so it works whether or not customConfig is enabled. Set to [] to fall back
+# to whatever CMD the image defines.
+command:
+  - /gen3/start.sh
+
 # -- (map) Docker image information.
 image:
   # -- (string) Docker repository.


### PR DESCRIPTION
commons-frontend-app images build their CMD as ./start_with_config.sh, which recent builds no longer ship - the image only carries /gen3/start.sh. Every deployment on the default image exits immediately with "sh: can't open ./start_with_config.sh" and crashloops. This is currently breaking five dev namespaces on devplanetv2; the ones that stay up all run custom downstream images rather than the default.

Sets the command explicitly to /gen3/start.sh, which runs the same standalone server and prints "Config not yet mounted" rather than failing when the config directory is absent, so it works whether or not customConfig is enabled. Verified against quay.io/cdis/commons-frontend-app:main in-cluster: the pod reaches Ready and serves HTTP on 3000.

The command is a values key, so an environment needing a different entrypoint can override it, and setting it to [] falls back to the image's own CMD.

<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one:

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
