### PR TITLE
Feat: add clean up spec to ensure the ohdsi-webapi-client-job is cleaned up 2 min after finishing

### DIFF
--- a/helm/ohdsi-webapi/templates/ohdsi-webapi-client-create-job.yaml
+++ b/helm/ohdsi-webapi/templates/ohdsi-webapi-client-create-job.yaml
@@ -142,4 +142,6 @@ spec:
                     \"security_oid_clientId\":\"${FENCE_CLIENT_ID}\",
                     \"security_oid_apiSecret\":\"${FENCE_CLIENT_SECRET}\"
                 }}"
+              echo -e "\n\n>>========== Restarting webapi pods so they pick up new config above ============\n\n"
+              kubectl delete pod -l app=ohdsi-webapi
 {{- end }}

--- a/helm/ohdsi-webapi/templates/ohdsi-webapi-client-create-job.yaml
+++ b/helm/ohdsi-webapi/templates/ohdsi-webapi-client-create-job.yaml
@@ -4,6 +4,7 @@ kind: Job
 metadata:
   name: ohdsi-webapi-client-job
 spec:
+  ttlSecondsAfterFinished: 120
   template:
     metadata:
       labels:

--- a/helm/ohdsi-webapi/templates/serviceaccount.yaml
+++ b/helm/ohdsi-webapi/templates/serviceaccount.yaml
@@ -16,6 +16,9 @@ rules:
   resources: ["secrets"]
   resourceNames: ["fence-dbcreds"]
   verbs: ["get"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/MC2DP-1078

### New Features

### Breaking Changes

### Bug Fixes

### Improvements
- add clean up spec to ensure the ohdsi-webapi-client-job is cleaned up 2 min after finishing, which ensures it can run again in a next deployment / upgrade of the service. Without this, the job stays there and blocks new/future instances
- also included an auto restart of webapi pods so they pick up new auto-pached fence client config

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
